### PR TITLE
Added Support for 'Erase App Settings' Command

### DIFF
--- a/Source/Managers/BasicManager.swift
+++ b/Source/Managers/BasicManager.swift
@@ -1,0 +1,38 @@
+//
+//  BasicManager.swift
+//  
+//
+//  Created by Dinesh Harjani on 21/9/21.
+//
+
+import Foundation
+import SwiftCBOR
+
+// MARK: - BasicManager
+
+/// Sends commands belonging to the Basic Group.
+///
+public class BasicManager: McuManager {
+    override class var TAG: McuMgrLogCategory { .basic }
+    
+    // MARK: - Constants
+
+    enum ID: UInt8 {
+        case Reset = 0
+    }
+    
+    // MARK: - Init
+    
+    public init(transporter: McuMgrTransport) {
+        super.init(group: .basic, transporter: transporter)
+    }
+    
+    // MARK: - Commands
+
+    /// Erase stored Application-Level Settings from the Application Core.
+    ///
+    /// - parameter callback: The response callback with a ``McuMgrResponse``.
+    public func eraseAppSettings(callback: @escaping McuMgrCallback<McuMgrResponse>) {
+        send(op: .write, commandId: ID.Reset.rawValue, payload: [:], callback: callback)
+    }
+}

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -245,6 +245,8 @@ public enum McuMgrGroup {
     case run
     /// File System command group (FileSystemManager).
     case fs
+    /// Basic command group (BasicManager).
+    case basic
     /// Per user command group, value must be >= 64.
     case peruser(value: UInt16)
     
@@ -259,6 +261,7 @@ public enum McuMgrGroup {
         case .split: return 6
         case .run: return 7
         case .fs: return 8
+        case .basic: return 63
         case .peruser(let value): return value
         }
     }

--- a/Source/McuMgrLogDelegate.swift
+++ b/Source/McuMgrLogDelegate.swift
@@ -49,6 +49,7 @@ public enum McuMgrLogCategory: String {
     case runTest   = "RunTestManager"
     case stats     = "StatsManager"
     case dfu       = "DFU"
+    case basic     = "BasicManager"
 }
 
 /// The Logger delegate.


### PR DESCRIPTION
This is implemented via the new BasicManager, belonging to a new group, which should be extended in the future as its capabilities grow. For now, it's only used for the 'eraseAppSettings' command, which is enabled by default.