### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "McuManager",
-    platforms: [.iOS(.v9), .macOS(.v10_13)],
+    platforms: [.iOS(.v10), .macOS(.v10_13)],
     products: [
         .library(
             name: "McuManager",


### PR DESCRIPTION
fix issue
The package product 'SwiftCBOR' requires minimum platform version 10.0 for the iOS platform, but this target supports 9.0