### PR TITLE
Fix: SwiftCBOR dependency was tied to 'master'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/unrelentingtech/SwiftCBOR.git", 
-            .branch("master")
+            url: "https://github.com/unrelentingtech/SwiftCBOR.git",
+            .exact("0.4.4")
         ),
     ],
     targets: [


### PR DESCRIPTION
The problem is SwiftCBOR has upped their minimum version to iOS 10, but we still want to support iOS 9, so we've changed our dependency to match version 0.4.4, which is the last version supporting iOS 9.