### PR TITLE
Infinite Confirm/Reset loop when running in testAndConfirm mode.

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -683,7 +683,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         }
         
         self.log(msg: "Upgrade complete.", atLevel: .application)
-        self.reset()
+        self.success()
     }
 }
 


### PR DESCRIPTION
When implementing this library in my own project, I found that if I ran the Firmware Upgrade Manager in testAndConfirm mode, it would do everything properly up until the last step, where instead of marking the state as successful it would just throw itself into an infinite loop of resetting and confirming the firmware.

Changing the self.reset() call to a self.success() call, mimicking FirmwareUpgradeManager's reconnect function fixes this problem.