### PR TITLE
Fix: .confirmOnly requires reset() call, but .testAndConfirm requires success() call at the end of Confirm Callback

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -685,10 +685,8 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         self.log(msg: "Upgrade complete.", atLevel: .application)
         switch self.mode {
         case .confirmOnly:
-            self.log(msg: "Mode set to 'Confirm Only'. Finishing with call to reset().", atLevel: .debug)
             self.reset()
         case .testAndConfirm:
-            self.log(msg: "Mode set to 'Test and Confirm'. Finishing with call to success().", atLevel: .debug)
             self.success()
         case .testOnly:
             // Impossible!

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -683,7 +683,17 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         }
         
         self.log(msg: "Upgrade complete.", atLevel: .application)
-        self.success()
+        switch self.mode {
+        case .confirmOnly:
+            self.log(msg: "Mode set to 'Confirm Only'. Finishing with call to reset().", atLevel: .debug)
+            self.reset()
+        case .testAndConfirm:
+            self.log(msg: "Mode set to 'Test and Confirm'. Finishing with call to success().", atLevel: .debug)
+            self.success()
+        case .testOnly:
+            // Impossible!
+            return
+        }
     }
 }
 


### PR DESCRIPTION
This was all prompted by a Pull Request by a user. And yes, we did do the check to see that with reset(), after successful reconnection a success() call is sent up through the API ranks.