### PR TITLE
Improvements

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iOSMcuManagerLibrary (1.1.0):
+  - iOSMcuManagerLibrary (1.2.1):
     - SwiftCBOR (= 0.4.4)
   - SwiftCBOR (0.4.4)
   - ZIPFoundation (0.9.11)
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSMcuManagerLibrary: 64853befc4e6ff100809069f308cbf6ba38ec033
+  iOSMcuManagerLibrary: 33aec5d9986c4322668a0c908b13f3b7e2fe0635
   SwiftCBOR: ce5354ec8b660da2d6fc754462881119dbe1f963
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 

--- a/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
@@ -124,7 +124,6 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
             return
         }
         
-        log(msg: "peripheralDidUpdateValueFor() SEQ No. \(sequenceNumber))", atLevel: .debug)
         writeState.received(sequenceNumber: sequenceNumber, data: data)
     }
 }

--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -339,8 +339,8 @@ extension McuMgrBleTransport: McuMgrTransport {
                 return .failure(McuMgrTransportError.sendFailed)
             }
             
-            for (i, chunk) in dataChunks.enumerated() {
-                log(msg: "-> (SEQ No. \(sequenceNumber), Chunk \(i)) \(chunk.hexEncodedString(options: .prepend0x))", atLevel: .debug)
+            for chunk in dataChunks {
+                log(msg: "-> \(chunk.hexEncodedString(options: .prepend0x))", atLevel: .debug)
                 targetPeripheral.writeValue(chunk, for: smpCharacteristic, type: .withoutResponse)
             }
         } else {
@@ -349,7 +349,7 @@ extension McuMgrBleTransport: McuMgrTransport {
                 return .failure(McuMgrTransportError.insufficientMtu(mtu: mtu))
             }
             
-            log(msg: "-> (SEQ No. \(sequenceNumber)) \(data.hexEncodedString(options: .prepend0x))", atLevel: .debug)
+                log(msg: "-> \(data.hexEncodedString(options: .prepend0x))", atLevel: .debug)
             targetPeripheral.writeValue(data, for: smpCharacteristic, type: .withoutResponse)
         }
 
@@ -366,13 +366,8 @@ extension McuMgrBleTransport: McuMgrTransport {
         case .success:
             guard let returnData = writeState[sequenceNumber]?.chunk else {
                 return .failure(McuMgrTransportError.badHeader)
-            }
-            
-            if let writeResponse = try? McuMgrResponse.buildResponse(scheme: .ble, data: returnData) {
-                log(msg: "<- (SEQ No. \(sequenceNumber)) Response: \(writeResponse))", atLevel: .debug)
-            }
-            
-            log(msg: "<- (SEQ No(s). \(sequenceNumber)) \(returnData.hexEncodedString(options: .prepend0x))", atLevel: .debug)
+            }            
+            log(msg: "<- \(returnData.hexEncodedString(options: .prepend0x))", atLevel: .debug)
             return .success(returnData)
         }
     }
@@ -381,8 +376,8 @@ extension McuMgrBleTransport: McuMgrTransport {
         connectionLock.close()
     }
     
-    internal func log(msg: String, atLevel level: McuMgrLogLevel) {
-        logDelegate?.log(msg, ofCategory: .transport, atLevel: level)
+    internal func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
+        logDelegate?.log(msg(), ofCategory: .transport, atLevel: level)
     }
 }
 

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -693,6 +693,13 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
                 
                 // Check that the new image is in permanent state.
                 guard secondary.permanent else {
+                    // If a TEST command was sent before for the image that is to be confirmed we have to reset.
+                    // It is not possible to confirm such image until the device is reset.
+                    // A new DFU operation has to be performed to confirm the image.
+                    guard !secondary.pending else {
+                        self.reset()
+                        return
+                    }
                     guard self.images[j].confirmed else {
                         self.confirm(self.images[j])
                         return

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -176,14 +176,16 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     
     private func requestMcuMgrParameters() {
         setState(.requestMcuMgrParameters)
-        guard !paused else { return }
-        self.log(msg: "Requesting McuMgr Parameters...", atLevel: .debug)
-        self.defaultManager.params(callback: self.mcuManagerParametersCallback)
+        if !paused {
+            log(msg: "Requesting McuMgr parameters...", atLevel: .debug)
+            defaultManager.params(callback: self.mcuManagerParametersCallback)
+        }
     }
     
     private func validate() {
         setState(.validate)
         if !paused {
+            log(msg: "Sending Image List command...", atLevel: .application)
             imageManager.list(callback: validateCallback)
         }
     }
@@ -191,10 +193,11 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     private func upload() {
         setState(.upload)
         if !paused {
+            log(msg: "Uploading images...", atLevel: .application)
             let imagesToUpload = images
-                .filter({ !$0.uploaded })
+                .filter { !$0.uploaded }
                 .sorted(by: <)
-                .map({ ImageManager.Image($0.image, $0.data) })
+                .map { ImageManager.Image($0.image, $0.data) }
             _ = imageManager.upload(images: imagesToUpload, using: configuration, delegate: self)
         }
     }
@@ -202,6 +205,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     private func test(_ image: FirmwareUpgradeImage) {
         setState(.test)
         if !paused {
+            log(msg: "Sending Test command for image \(image.image)...", atLevel: .application)
             imageManager.test(hash: [UInt8](image.hash), callback: testCallback)
         }
     }
@@ -209,8 +213,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     private func confirm(_ image: FirmwareUpgradeImage) {
         setState(.confirm)
         if !paused {
-            self.log(msg: "Sending CONFIRM Command for Image \(image.image)...", atLevel: .application)
-            self.log(msg: "Sending CONFIRM Command for image \(image.image) with hash \([UInt8](image.hash))...", atLevel: .debug)
+            log(msg: "Sending Confirm command for image \(image.image)...", atLevel: .application)
             imageManager.confirm(hash: [UInt8](image.hash), callback: confirmCallback)
         }
     }
@@ -219,6 +222,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         setState(.confirm)
         if !paused {
             // This will confirm the image on slot 0
+            log(msg: "Sending Config command...", atLevel: .application)
             imageManager.confirm(callback: confirmCallback)
         }
     }
@@ -226,6 +230,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     private func reset() {
         setState(.reset)
         if !paused {
+            log(msg: "Sending Reset command...", atLevel: .application)
             defaultManager.transporter.addObserver(self)
             defaultManager.reset(callback: resetCallback)
         }
@@ -324,11 +329,9 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             if primary != nil {
                 if Data(primary.hash) == self.images[j].hash {
                     self.images[j].uploaded = true
-                    self.log(msg: "Image \(j)'s primary slot is already uploaded.", atLevel: .application)
                     
                     if primary.confirmed || primary.permanent {
                         // The new firmware is already active and confirmed.
-                        self.log(msg: "Image \(j)'s is already confirmed.", atLevel: .application)
                         self.images[j].confirmed = true
                         continue
                     } else {
@@ -487,7 +490,6 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             guard secondary.pending else {
                 // For every image we upload, we need to send it the TEST Command.
                 guard self.images[j].tested else {
-                    self.log(msg: "Image \(j) is not in Pending state. Sending TEST Command.", atLevel: .info)
                     self.test(self.images[j])
                     return
                 }
@@ -497,7 +499,6 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
                 return
             }
             self.images[j].tested = true
-            self.log(msg: "Image \(j) is in Pending state.", atLevel: .info)
         }
         
         // Test image succeeded. Begin device reset.
@@ -524,8 +525,8 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             self.fail(error: FirmwareUpgradeError.mcuMgrReturnCodeError(response.returnCode))
             return
         }
+        self.log(msg: "Erasing app settings completed", atLevel: .application)
         
-        self.log(msg: "Erase App Settings Succesful. Proceeding.", atLevel: .application)
         // Set to false so uploadDidFinish() doesn't loop forever.
         self.configuration.eraseAppSettings = false
         self.uploadDidFinish()
@@ -539,13 +540,12 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         guard let self = self else { return }
         
         guard error == nil, let response = response, response.rc != 8 else {
-            self.log(msg: "Received Error or invalid McuMgrParameters Response. This is expected if the receiving firmware does not support McuMgrParameters. Proceeding as normal.", atLevel: .debug)
             self.configuration.reassemblyBufferSize = 0
             self.validate() // Continue Upload
             return
         }
         
-        self.log(msg: "Received McuMgrParameters Response for increased speed. Setting Reassembly Buffer Size to \(response.bufferSize).", atLevel: .debug)
+        self.log(msg: "Setting SAR buffer size to \(response.bufferSize) bytes", atLevel: .debug)
         self.configuration.reassemblyBufferSize = response.bufferSize
         self.validate() // Continue Upload
     }
@@ -675,13 +675,12 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
             switch self.mode {
             case .confirmOnly:
                 guard !self.images[j].confirmed else {
-                    self.log(msg: "Skipping Image \(j)'s confirm step since it is already confirmed.", atLevel: .debug)
                     continue
                 }
                 
                 // If not already confirmed/uploaded, the new image should be in slot 1.
                 guard let secondary = responseImages.first(where: { $0.image == j && $0.slot == 1 }) else {
-                    self.log(msg: "Unable to find secondary slot for Image \(j) in Image listing.", atLevel: .debug)
+                    // Unable to find Image j in secondary slot
                     
                     guard let primary = responseImages.first(where: { $0.image == j && $0.slot == 0 }) else {
                         self.fail(error: FirmwareUpgradeError.invalidResponse(response))
@@ -689,24 +688,21 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
                     }
                     
                     self.images[j].confirmed = true
-                    self.log(msg: "Image \(j) does not require confirm command since it is already present and confirmed in its respective slot zero.", atLevel: .debug)
                     continue
                 }
                 
                 // Check that the new image is in permanent state.
                 guard secondary.permanent else {
                     guard self.images[j].confirmed else {
-                        self.log(msg: "Sending CONFIRM Command for Image \(secondary.image).", atLevel: .debug)
                         self.confirm(self.images[j])
                         return
                     }
                     
                     // If we've sent it the CONFIRM Command, the secondary slot must be in PERMANENT state.
-                    self.fail(error: FirmwareUpgradeError.unknown("Image \(secondary.image) Slot \(secondary.slot) is not in a permanent state."))
+                    self.fail(error: FirmwareUpgradeError.unknown("Image \(secondary.image) in slot \(secondary.slot) is not in a permanent state."))
                     return
                 }
                 
-                self.log(msg: "Image \(secondary.image) already confirmed (\"permanent: true\") in Slot \(secondary.slot).", atLevel: .debug)
                 self.images[j].confirmed = true
             case .testAndConfirm:
                 if let primary = responseImages.first(where: { $0.image == j && $0.slot == 0 }) {
@@ -721,8 +717,6 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
                         return
                     }
                     self.images[j].confirmed = true
-                } else {
-                    self.log(msg: "Skipping Image \(j) hash verification since primary is not available.", atLevel: .info)
                 }
             case .testOnly:
                 // Impossible state. Ignore.
@@ -745,8 +739,8 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
 
 private extension FirmwareUpgradeManager {
     
-    func log(msg: String, atLevel level: McuMgrLogLevel) {
-        logDelegate?.log(msg, ofCategory: .dfu, atLevel: level)
+    func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
+        logDelegate?.log(msg(), ofCategory: .dfu, atLevel: level)
     }
 }
 
@@ -807,7 +801,7 @@ extension FirmwareUpgradeManager: ImageUploadDelegate {
         // Before we can move on, we must check whether the user requested for App Core Settings
         // to be erased.
         if configuration.eraseAppSettings {
-            log(msg: "'Erase App Settings' Enabled. Sending command...", atLevel: .info)
+            log(msg: "Sending Erase App Storage command...", atLevel: .application)
             basicManager.eraseAppSettings(callback: eraseAppSettingsCallback)
             return
         }

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -164,7 +164,6 @@ public class ImageManager: McuManager {
         log(msg: "Uploading image \(firstImage.image) (\(firstImage.data.count) bytes)...", atLevel: .application)
         let firstOffset = maxDataPacketLengthFor(data: firstImage.data, image: firstImage.image, offset: 0)
         uploadExpectedOffsets.append(firstOffset)
-        log(msg: "Uploading image \(firstImage.image) from \(firstOffset)/\(firstImage.data.count)...", atLevel: .debug)
         upload(data: firstImage.data, image: firstImage.image, offset: 0, alignment: configuration.byteAlignment,
                callback: uploadCallback)
         return true
@@ -313,7 +312,7 @@ public class ImageManager: McuManager {
             let image: Int! = self.uploadImages?[uploadIndex].image
             uploadState = .uploading
             let offset = uploadLastOffset ?? 0
-            log(msg: "[Continue] Uploading image \(image) from \(offset)/\(imageData.count)...", atLevel: .application)
+            log(msg: "Resuming uploading image \(image) from \(offset)/\(imageData.count)...", atLevel: .application)
             let firstResumeOffset = offset + maxDataPacketLengthFor(data: imageData, image: image, offset: offset)
             uploadExpectedOffsets.append(firstResumeOffset)
             upload(data: imageData, image: image, offset: offset, alignment: uploadConfiguration.byteAlignment,
@@ -367,7 +366,6 @@ public class ImageManager: McuManager {
             // because otherwise we can't predict how many bytes the firmware will accept.
             if self.uploadConfiguration.pipelineDepth > 1 {
                 if let uploadIndex = self.uploadExpectedOffsets.firstIndex(of: UInt64(offset)) {
-                    self.log(msg: "ACK for offset \(offset) for image \(self.uploadIndex)", atLevel: .debug)
                     self.uploadExpectedOffsets.remove(at: uploadIndex)
                 } else {
                     // We've missed an offset, so let's compensate or else the upload will stall.
@@ -425,7 +423,7 @@ public class ImageManager: McuManager {
             for i in 0..<(self.uploadConfiguration.pipelineDepth - self.uploadExpectedOffsets.count) {
                 guard let chunkOffset = self.uploadExpectedOffsets.last ?? self.uploadLastOffset,
                       chunkOffset < self.imageData?.count ?? 0 else {
-                    self.log(msg: "No remaining chunks to send for i = \(i), chunkOffset = (\(self.uploadExpectedOffsets.last ?? self.uploadLastOffset)), and imageSize = (\(self.imageData?.count)).", atLevel: .debug)
+                    // No remaining chunks to be sent.
                     return
                 }
                 
@@ -441,8 +439,8 @@ public class ImageManager: McuManager {
     private func sendNext(from offset: UInt64) {
         let imageData: Data! = self.uploadImages?[uploadIndex].data
         let imageSlot: Int! = self.uploadImages?[uploadIndex].image
-        log(msg: "[Next] Uploading image \(imageSlot) from \(offset)/\(imageData.count)...", atLevel: .debug)
-        upload(data: imageData, image: imageSlot, offset: offset, alignment: uploadConfiguration.byteAlignment,
+        upload(data: imageData, image: imageSlot, offset: offset,
+               alignment: uploadConfiguration.byteAlignment,
                callback: uploadCallback)
     }
     

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -76,7 +76,7 @@ open class McuManager {
         let packetPacketSequenceNumber = sequenceNumber
         sequenceNumber = sequenceNumber.next()
         
-        log(msg: "Sending \(op) command (Group: \(group), SEQ No. \(packetPacketSequenceNumber), ID: \(commandId)): \(payload?.debugDescription ?? "nil")",
+        log(msg: "Sending \(op) command (Group: \(group), seq: \(packetPacketSequenceNumber), ID: \(commandId)): \(payload?.debugDescription ?? "nil")",
             atLevel: .verbose)
         let mcuPacketData = McuManager.buildPacket(scheme: transporter.getScheme(), op: op,
                                                    flags: flags, group: group.uInt16Value,
@@ -85,10 +85,10 @@ open class McuManager {
         let _callback: McuMgrCallback<T> = logDelegate == nil ? callback : { [weak self] (response, error) in
             if let self = self {
                 if let response = response {
-                    self.log(msg: "Response (Group: \(self.group), SEQ No. \(packetPacketSequenceNumber), ID: \(response.header!.commandId!)): \(response)",
+                    self.log(msg: "Response (Group: \(self.group), seq: \(packetPacketSequenceNumber), ID: \(response.header!.commandId!)): \(response)",
                              atLevel: .verbose)
                 } else if let error = error {
-                    self.log(msg: "Request (Group: \(self.group), SEQ No. \(packetPacketSequenceNumber)) failed: \(error.localizedDescription))",
+                    self.log(msg: "Request (Group: \(self.group), seq: \(packetPacketSequenceNumber)) failed: \(error.localizedDescription))",
                              atLevel: .error)
                 }
             }
@@ -221,8 +221,8 @@ open class McuManager {
 
 extension McuManager {
     
-    func log(msg: String, atLevel level: McuMgrLogLevel) {
-        logDelegate?.log(msg, ofCategory: Self.TAG, atLevel: level)
+    func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
+        logDelegate?.log(msg(), ofCategory: Self.TAG, atLevel: level)
     }
     
 }


### PR DESCRIPTION
This PR improves logging (by removing unnecessary logs) and fixes a bug causing an endless confirm loop when the image is in "pending" state (that is a TEST command was sent for it). Now, when unable to confirm the image, the library will reset the device. This will make the device to restart with the new (or old firmware) and a new DFU operation can be performed to update the device again.