### PR TITLE
Fix for Confirmation-Loop Bug when Starting Multi-Image DFU with unsorted Image(s)

### DIFF
--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -403,7 +403,7 @@ public class ImageManager: McuManager {
                     // Release cyclic reference.
                     self.cyclicReferenceHolder = nil
                 } else {
-                    self.log(msg: "Uploaded image \(self.uploadIndex) (\(self.uploadIndex + 1) of \(images.count))", atLevel: .application)
+                    self.log(msg: "Uploaded image \(images[self.uploadIndex].image) (\(self.uploadIndex + 1) of \(images.count))", atLevel: .application)
                     // Move on to the next image.
                     self.uploadIndex += 1
                     self.imageData = images[self.uploadIndex].data


### PR DESCRIPTION
Bug was caused by starting a muilti-image DFU Upload wherein the images were in the wrong order. The for-loop inside confirmationCallback expects self.image[j] to match j, otherwise we might mark the incorrect image as confirmed but skip over the one that is not confirmed in the loop itself (guard statement checking our own properties whether an image is confirmed). This extends further into test and validate stages, where we also made some changes to the code.