### PR TITLE
Fix for situation where the same image is in both slots

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -1009,14 +1009,10 @@ extension FirmwareUpgradeImage: Hashable {
 
 // MARK: - FirmwareUpgradeImage Comparable
 
-extension FirmwareUpgradeImage: Comparable {
+extension FirmwareUpgradeImage: Equatable {
     
-    public static func < (lhs: FirmwareUpgradeImage, rhs: FirmwareUpgradeImage) -> Bool {
-        if lhs.image < rhs.image {
-            return true
-        } else if lhs.image > rhs.image {
-            return false
-        }
-        return lhs.hashValue < rhs.hashValue
+    public static func == (lhs: FirmwareUpgradeImage, rhs: FirmwareUpgradeImage) -> Bool {
+        return lhs.hash == rhs.hash
     }
+    
 }


### PR DESCRIPTION
This PR fixes the endless loop happening when the same image is in both primary and secondary slot of an image.
In #55 (and before) the flags of each image in the `images` property in DFU manager were modified multiple times. 
https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/blob/bab7cba94ec1944f99461a8f1a19ca9dcf552d65/Source/Managers/DFU/FirmwareUpgradeManager.swift#L353-L370
However, as `FirmwareUpgradeImage` is a `struct`, each modification is effectively replacing the image object with a new struct. The following call to `markAs...(_ image:)` was not finding the image instance, and returning, without changing the flag.

The image, in the above case, was marked as uploaded, but not as confirmed or tested, thus the library tried to test it again. As it was already in the primary and secondary slot, the confirm call was acting on the primary slot, but the check was verifying the secondary slot, which was never confirmed (why would it be).
Now, it will not be sent twice in the first place, will be marked as confirmed and no additional confirm commands will be sent.