### PR TITLE
McuMgrPackage is now Marked as Public

### DIFF
--- a/Example/Example/Util/McuMgrPackage.swift
+++ b/Example/Example/Util/McuMgrPackage.swift
@@ -12,7 +12,7 @@ import ZIPFoundation
 
 // MARK: - McuMgrPackage
 
-struct McuMgrPackage {
+public struct McuMgrPackage {
     
     let images: [ImageManager.Image]
     


### PR DESCRIPTION
This means it is exposed to any library user.