### PR TITLE
Fix for NaN Upload Speed

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -306,7 +306,7 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
         }
         
         // Date.timeIntervalSince1970 returns seconds
-        let msSinceUploadBegan = (timestamp.timeIntervalSince1970 - uploadTimestamp.timeIntervalSince1970) * 1000
+        let msSinceUploadBegan = max((timestamp.timeIntervalSince1970 - uploadTimestamp.timeIntervalSince1970) * 1000, 1)
         
         guard bytesSent < imageSize else {
             let averageSpeedInKiloBytesPerSecond = Double(imageSize - initialBytes) / msSinceUploadBegan

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -189,7 +189,7 @@ extension FirmwareUploadViewController: ImageUploadDelegate {
         }
         
         // Date.timeIntervalSince1970 returns seconds
-        let msSinceUploadBegan = (timestamp.timeIntervalSince1970 - uploadTimestamp.timeIntervalSince1970) * 1000
+        let msSinceUploadBegan = max((timestamp.timeIntervalSince1970 - uploadTimestamp.timeIntervalSince1970) * 1000, 1)
         
         guard bytesSent < imageSize else {
             let averageSpeedInKiloBytesPerSecond = Double(imageSize - initialBytes) / msSinceUploadBegan


### PR DESCRIPTION
Dividing by a very small number smaller than 1 is not usually a good idea when it comes to Float(s) and Double(s).