### PR TITLE
Fix: Don't expect Sequence Number in all Data packet responses

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
@@ -29,11 +29,11 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
     }
     
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        guard self.identifier == peripheral.identifier else {
-            return
-        }
+        guard self.identifier == peripheral.identifier else { return }
+        
         log(msg: "Peripheral connected", atLevel: .info)
         state = .initializing
+        previousUpdateNotificationSequenceNumber = nil
         log(msg: "Discovering services...", atLevel: .verbose)
         peripheral.delegate = self
         peripheral.discoverServices([McuMgrBleTransportConstant.SMP_SERVICE])

--- a/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
@@ -119,11 +119,16 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
             return
         }
         
-        guard let sequenceNumber = data.readMcuMgrHeaderSequenceNumber() else {
+        // Assumption: CoreBluetooth is delivering all packets from the same sender,
+        // i.e. sequence number, in order. So if the Data is the first 'chunk', it will
+        // include the header. If not, we can presume the SequenceNumber matches the
+        // previously read value.
+        guard let sequenceNumber = data.readMcuMgrHeaderSequenceNumber() ?? previousUpdateNotificationSequenceNumber else {
             writeState.onError(McuMgrTransportError.badHeader)
             return
         }
         
+        previousUpdateNotificationSequenceNumber = sequenceNumber
         writeState.received(sequenceNumber: sequenceNumber, data: data)
     }
 }

--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -49,6 +49,8 @@ public class McuMgrBleTransport: NSObject {
     internal let connectionLock: ResultLock
     /// Used to track multiple write requests and their responses.
     internal var writeState: McuMgrBleTransportWriteState
+    /// Used to track the Sequence Number the chunked responses belong to.
+    internal var previousUpdateNotificationSequenceNumber: UInt8?
     
     /// SMP Characteristic object. Used to write requests and receive
     /// notificaitons.


### PR DESCRIPTION
When SMP Reassembly is enabled, the firmware needs to 'chunk' the Data on the other side and send it to us. The Sender is not obliged to include the header