### PR TITLE
Release cyclic reference after upgradeDidComplete

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -243,9 +243,10 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         paused = false
         DispatchQueue.main.async { [weak self] in
             self?.delegate?.upgradeDidComplete()
+            // Release cyclic reference.
+            cyclicReferenceHolder = nil
+            self?.cyclicReferenceHolder = nil
         }
-        // Release cyclic reference.
-        cyclicReferenceHolder = nil
         objc_sync_exit(self)
     }
     

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -244,7 +244,6 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         DispatchQueue.main.async { [weak self] in
             self?.delegate?.upgradeDidComplete()
             // Release cyclic reference.
-            cyclicReferenceHolder = nil
             self?.cyclicReferenceHolder = nil
         }
         objc_sync_exit(self)


### PR DESCRIPTION
This concerns the following issue:

https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/69

The cyclic reference is released too fast so upgradeDidComplete will never fire. 