### PR TITLE
McuManager Sequence Number Callback Reordering

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransportWriteState.swift
+++ b/Source/Bluetooth/McuMgrBleTransportWriteState.swift
@@ -32,6 +32,7 @@ final class McuMgrBleTransportWriteState {
     
     func newWrite(sequenceNumber: UInt8, lock: ResultLock) {
         lockingQueue.async {
+            // Either there's no state for that Sequence Number, or the Lock is Open.
             self.state[sequenceNumber] = (sequenceNumber: sequenceNumber, writeLock: lock, nil, nil)
         }
     }


### PR DESCRIPTION
Previously, calls to send()' command in McuManager were not returned in-order. They were returned as they were returned by CoreBluetooth, leaving the re-ordering to higher-levels. But now, McuManager now buffers callbacks in case it detects a different Sequence Number it's not expecting, and keeps the results and the callbacks until it has enough stored results to return them in-order.