### PR TITLE
Fix for failed DFU when first sending 'echo' messages from Device Tab

### DIFF
--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -53,6 +53,12 @@ class DeviceController: UITableViewController, UITextFieldDelegate {
         bleTransporter?.delegate = connectionStatus
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        // Close the connection to allow other UIViewController(s) to do
+        // their own thing.
+        defaultManager.transporter.close()
+    }
+    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         sendTapped(actionSend)
         return true


### PR DESCRIPTION
If we select a Device, then send multiple messages from Device Tab, then go to Image and perform a DFU, it'd stall. It'd work with Pipelining Disabled, but not with Pipelining. I chased this issue to the ends of the Earth. In the end, I think what was happening is that the firmware / peripheral was not returning the messages because within the same connection, the Sequence Numbers were switching back from above zero to zero, because the connection is kept, but not the manager(s), which each track their own Sequence Number. So obviously if commands with, say, sequence numbers 0-7 were sent to and replied to, and then we start DFU with sequence number 0, obviously the firmware is not going to reply back.