### PR TITLE
McuSequenceNumber Typealias Type for UInt8

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -50,7 +50,7 @@ public class McuMgrBleTransport: NSObject {
     /// Used to track multiple write requests and their responses.
     internal var writeState: McuMgrBleTransportWriteState
     /// Used to track the Sequence Number the chunked responses belong to.
-    internal var previousUpdateNotificationSequenceNumber: UInt8?
+    internal var previousUpdateNotificationSequenceNumber: McuSequenceNumber?
     
     /// SMP Characteristic object. Used to write requests and receive
     /// notificaitons.

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -552,7 +552,7 @@ public enum ImageUploadError: Error {
     /// Image Data is nil.
     case invalidData
     
-    case invalidUploadSequenceNumber(UInt8)
+    case invalidUploadSequenceNumber(McuSequenceNumber)
     /// McuMgrResponse contains a error return code.
     case mcuMgrErrorCode(McuMgrReturnCode)
 }

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -8,6 +8,14 @@ import Foundation
 import CoreBluetooth
 import SwiftCBOR
 
+/**
+ Valid values are within the bounds of UInt8 (0...255).
+ 
+ For capabilities such as pipelining, incrementing and wrapping around
+ the Sequence Number for every `McuManager command is required.
+ */
+public typealias McuSequenceNumber = UInt8
+
 open class McuManager {
     class var TAG: McuMgrLogCategory { .default }
     
@@ -50,10 +58,10 @@ open class McuManager {
     
     /// Each 'send' command gets its own Sequence Number, which we rotate
     /// within the bounds of an unsigned UInt8 [0...255].
-    private var nextSequenceNumber: UInt8 = 0
+    private var nextSequenceNumber: McuSequenceNumber = 0
     
-    private var pendingSequenceNumbers: [UInt8] = []
-    private var robResultBuffer: [UInt8: Any?] = [:]
+    private var pendingSequenceNumbers: [McuSequenceNumber] = []
+    private var robResultBuffer: [McuSequenceNumber: Any?] = [:]
     
     //**************************************************************************
     // MARK: Initializers
@@ -146,8 +154,9 @@ open class McuManager {
     /// - parameter payload: The request payload.
     ///
     /// - returns: The raw packet data to send to the transporter.
-    public static func buildPacket<R: RawRepresentable>(scheme: McuMgrScheme, op: McuMgrOperation, flags: UInt8,
-                                                        group: UInt16, sequenceNumber: UInt8,
+    public static func buildPacket<R: RawRepresentable>(scheme: McuMgrScheme, op: McuMgrOperation,
+                                                        flags: UInt8, group: UInt16,
+                                                        sequenceNumber: McuSequenceNumber,
                                                         commandId: R, payload: [String:CBOR]?) -> Data where R.RawValue == UInt8 {
         // If the payload map is nil, initialize an empty map.
         var payload = (payload == nil ? [:] : payload)!

--- a/Source/McuMgrHeader.swift
+++ b/Source/McuMgrHeader.swift
@@ -16,7 +16,7 @@ public class McuMgrHeader {
     public let flags: UInt8!
     public let length: UInt16!
     public let groupId: UInt16!
-    public let sequenceNumber: UInt8!
+    public let sequenceNumber: McuSequenceNumber!
     public let commandId: UInt8!
     
     /// Initialize the header with raw data. Because this method only parses the
@@ -39,7 +39,8 @@ public class McuMgrHeader {
         commandId = data[7]
     }
     
-    public init(op: UInt8, flags: UInt8, length: UInt16, groupId: UInt16, sequenceNumber: UInt8, commandId: UInt8) {
+    public init(op: UInt8, flags: UInt8, length: UInt16, groupId: UInt16,
+                sequenceNumber: McuSequenceNumber, commandId: UInt8) {
         self.op = op
         self.flags = flags
         self.length = length
@@ -67,7 +68,8 @@ public class McuMgrHeader {
     /// - parameter group: The group id for this command.
     /// - parameter seq: Optional sequence number.
     /// - parameter id: The subcommand id for the given group.
-    public static func build(op: UInt8, flags: UInt8, len: UInt16, group: UInt16, seq: UInt8, id: UInt8) -> [UInt8] {
+    public static func build(op: UInt8, flags: UInt8, len: UInt16, group: UInt16, seq: McuSequenceNumber,
+                             id: UInt8) -> [UInt8] {
         return [op, flags, UInt8(len >> 8), UInt8(len & 0xFF), UInt8(group >> 8), UInt8(group & 0xFF), seq, id]
     }
 }
@@ -98,8 +100,8 @@ public enum McuMgrHeaderParseError: Error, LocalizedError {
 
 internal extension Data {
     
-    func readMcuMgrHeaderSequenceNumber() -> UInt8? {
+    func readMcuMgrHeaderSequenceNumber() -> McuSequenceNumber? {
         guard count >= McuMgrHeader.HEADER_LENGTH else { return nil }
-        return read(offset: 6) as UInt8
+        return read(offset: 6) as McuSequenceNumber
     }
 }


### PR DESCRIPTION
We use 'sequenceNumber' so much that I think it makes sense to give its representation its own 'type'. Even if it's just an alias for UInt8.