### PR TITLE
Relaxed 'image' or 'imageIndex' requirement for McuMgrManifest

### DIFF
--- a/Source/McuMgrManifest.swift
+++ b/Source/McuMgrManifest.swift
@@ -89,10 +89,6 @@ extension McuMgrManifest {
             _image = try? values.decode(Int.self, forKey: ._image)
             let imageIndexString = try? values.decode(String.self, forKey: ._imageIndex)
             guard let imageIndexString = imageIndexString else {
-                guard _image != nil else {
-                    throw DecodingError.dataCorruptedError(forKey: ._image, in: values,
-                                                           debugDescription: "'image' nor 'imageIndex' keys found.")
-                }
                 _imageIndex = nil
                 return
             }


### PR DESCRIPTION
Our Android counterpart defaults to image 0 so, we should do the same, as reported by a user that 'it works on Android'.