### PR TITLE
Do not trucate hash

### DIFF
--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -14,7 +14,6 @@ public class ImageManager: McuManager {
     override class var TAG: McuMgrLogCategory { .image }
     
     private static let PIPELINED_WRITES_TIMEOUT_SECONDS = 10
-    private static let truncatedHashLen = 3
     
     // MARK: - IDs
 
@@ -71,7 +70,7 @@ public class ImageManager: McuManager {
             }
             
             payload.updateValue(CBOR.unsignedInt(UInt64(data.count)), forKey: "len")
-            payload.updateValue(CBOR.byteString([UInt8](data.sha256()[0..<ImageManager.truncatedHashLen])), forKey: "sha")
+            payload.updateValue(CBOR.byteString([UInt8](data.sha256())), forKey: "sha")
         }
         
         let uploadTimeoutInSeconds = 1
@@ -512,7 +511,7 @@ public class ImageManager: McuManager {
             }
             
             payload.updateValue(CBOR.unsignedInt(UInt64(data.count)), forKey: "len")
-            payload.updateValue(CBOR.byteString([UInt8](repeating: 0, count: ImageManager.truncatedHashLen)), forKey: "sha")
+            payload.updateValue(CBOR.byteString([UInt8](data.sha256())), forKey: "sha")
         }
         // Build the packet and return the size.
         let packet = McuManager.buildPacket(scheme: transporter.getScheme(), op: .write, flags: 0,


### PR DESCRIPTION
The hash can optionally be used for image verification and should not be truncated.

Note that I have no way to test this.