### PR TITLE
API Change: McuManager setMtu() can now throw, rather than return a Boolean

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -138,16 +138,8 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         return state.isInProgress() && !paused
     }
     
-    /// Sets the MTU of the image upload. The MTU must be between 23 and 1024
-    /// (inclusive). The upload MTU determines the number of bytes sent in each
-    /// upload request. The MTU will default the the maximum available to the
-    /// phone and may change automatically if the end device's MTU is lower.
-    ///
-    /// - parameter mtu: The mtu to use in image upload.
-    ///
-    /// - returns: true if the mtu was within range, false otherwise
-    public func setUploadMtu(mtu: Int) -> Bool {
-        return imageManager.setMtu(mtu)
+    public func setUploadMtu(mtu: Int) throws {
+        try imageManager.setMtu(mtu)
     }
     
     //**************************************************************************

--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -282,10 +282,11 @@ public class FileSystemManager: McuManager {
         // Check for an error.
         if let error = error {
             if case let McuMgrTransportError.insufficientMtu(newMtu) = error {
-                if !self.setMtu(newMtu) {
-                    self.cancelTransfer(error: error)
-                } else {
+                do {
+                    try self.setMtu(newMtu)
                     self.restartTransfer()
+                } catch let mtuResetError {
+                    self.cancelTransfer(error: mtuResetError)
                 }
                 return
             }
@@ -352,10 +353,11 @@ public class FileSystemManager: McuManager {
         // Check for an error.
         if let error = error {
             if case let McuMgrTransportError.insufficientMtu(newMtu) = error {
-                if !self.setMtu(newMtu) {
-                    self.cancelTransfer(error: error)
-                } else {
+                do {
+                    try self.setMtu(newMtu)
                     self.restartTransfer()
+                } catch let mtuResetError {
+                    self.cancelTransfer(error: mtuResetError)
                 }
                 return
             }

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -341,10 +341,11 @@ public class ImageManager: McuManager {
         // Check for an error.
         if let error = error {
             if case let McuMgrTransportError.insufficientMtu(newMtu) = error {
-                if !self.setMtu(newMtu) {
-                    self.cancelUpload(error: error)
-                } else {
+                do {
+                    try self.setMtu(newMtu)
                     self.restartUpload()
+                } catch let mtuResetError {
+                    self.cancelUpload(error: mtuResetError)
                 }
                 return
             }


### PR DESCRIPTION
It's possible that setMTU() calls cause an infinite loop. And it's the same small piece of code that happens a couple of times in multiple managers, including the 'echo' command. And instead of patching it in five places, it's better to just make the code express itself better.