### PR TITLE
Fix: Erase App Settings does not Fail Fast Enough

### DIFF
--- a/Source/Managers/BasicManager.swift
+++ b/Source/Managers/BasicManager.swift
@@ -33,6 +33,6 @@ public class BasicManager: McuManager {
     ///
     /// - parameter callback: The response callback with a ``McuMgrResponse``.
     public func eraseAppSettings(callback: @escaping McuMgrCallback<McuMgrResponse>) {
-        send(op: .write, commandId: ID.Reset, payload: [:], callback: callback)
+        send(op: .write, commandId: ID.Reset, payload: [:], timeout: 1, callback: callback)
     }
 }

--- a/Source/McuMgrTransport.swift
+++ b/Source/McuMgrTransport.swift
@@ -41,7 +41,7 @@ public enum ConnectionResult {
 
 public typealias ConnectionCallback = (ConnectionResult) -> Void
 
-public enum McuMgrTransportError: Error {
+public enum McuMgrTransportError: Error, Hashable {
     /// Connection to the remote device has timed out.
     case connectionTimeout
     /// Connection to the remote device has failed.


### PR DESCRIPTION
Some firmware does not even reply back to the 'Erase App Settings' command, which was not being taken into account. So now we do, and if we get that specific error, we stop attempting to Erase App Settings directly and try to complete the DFU process as quickly as possible.