### PR TITLE
Fix: If your send() timeout is faster than the WAIT_AND_RETRY_INTERVAL, we lower the Wait and Retry Interval to said value

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -170,7 +170,8 @@ extension McuMgrBleTransport: McuMgrTransport {
             for i in 0..<McuMgrBleTransportConstant.MAX_RETRIES {
                 switch self._send(data: data, timeoutInSeconds: timeout) {
                 case .failure(McuMgrTransportError.waitAndRetry):
-                    sleep(UInt32(McuMgrBleTransportConstant.WAIT_AND_RETRY_INTERVAL))
+                    let waitInterval = min(timeout, McuMgrBleTransportConstant.WAIT_AND_RETRY_INTERVAL)
+                    sleep(UInt32(waitInterval))
                     if let header = try? McuMgrHeader(data: data) {
                         self.log(msg: "Retry \(i + 1) for Seq. No. \(header.sequenceNumber)", atLevel: .info)
                     } else {


### PR DESCRIPTION
The whole point of being able to set your timeout is that you can control how fast 'you fail'. If you want to fail really fast, but Wait and Retry doesn't let you, what's the point?