### PR TITLE
Fix: If Device Capabilities are not Supported, then Erase App Settings Isn't

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -301,14 +301,18 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         guard let self = self else { return }
         
         guard error == nil, let response = response, response.rc != 8 else {
-            self.log(msg: "Device capabilities not supported", atLevel: .warning)
+            self.log(msg: "Device capabilities not supported.", atLevel: .warning)
             self.configuration.reassemblyBufferSize = 0
+            if self.configuration.eraseAppSettings {
+                self.log(msg: "Cancelling 'Erase App Settings' since device capabilities are not supported.", atLevel: .info)
+                self.configuration.eraseAppSettings = false
+            }
             self.validate() // Continue Upload
             return
         }
         
-        self.log(msg: "Device capabilities received", atLevel: .application)
-        self.log(msg: "Setting SAR buffer size to \(response.bufferSize) bytes", atLevel: .debug)
+        self.log(msg: "Device capabilities received.", atLevel: .application)
+        self.log(msg: "Setting SAR buffer size to \(response.bufferSize) bytes.", atLevel: .debug)
         self.configuration.reassemblyBufferSize = response.bufferSize
         self.validate() // Continue Upload
     }


### PR DESCRIPTION
There's no point in sending an Erase App Settings Command if the firmware device is not going to reply back to it, which in turn leads to the Upload DFU to fail when it doesn't need to. Unfortunately at the moment we do not turn back the switch in the UI, but we do log the issue.