### PR TITLE
Added 'Erase App Settings' as a FirmwareUpgradeState value

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -225,12 +225,16 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
     func upgradeStateDidChange(from previousState: FirmwareUpgradeState, to newState: FirmwareUpgradeState) {
         status.textColor = .primary
         switch newState {
+        case .none:
+            status.text = ""
         case .requestMcuMgrParameters:
             status.text = "REQUESTING MCUMGR PARAMETERS..."
         case .validate:
             status.text = "VALIDATING..."
         case .upload:
             status.text = "UPLOADING..."
+        case .eraseAppSettings:
+            status.text = "ERASING APP SETTINGS..."
         case .test:
             status.text = "TESTING..."
         case .confirm:
@@ -239,8 +243,6 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
             status.text = "RESETTING..."
         case .success:
             status.text = "UPLOAD COMPLETE"
-        default:
-            status.text = ""
         }
     }
     

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -215,6 +215,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
     }
     
     private func eraseAppSettings() {
+        objc_sync_setState(.eraseAppSettings)
         log(msg: "Erasing app settings...", atLevel: .verbose)
         basicManager.eraseAppSettings(callback: eraseAppSettingsCallback)
     }
@@ -897,7 +898,10 @@ extension FirmwareUpgradeError: LocalizedError {
 //******************************************************************************
 
 public enum FirmwareUpgradeState {
-    case none, requestMcuMgrParameters, validate, upload, test, reset, confirm, success
+    case none
+    case requestMcuMgrParameters, eraseAppSettings
+    case upload, success
+    case validate, test, confirm, reset
     
     func isInProgress() -> Bool {
         return self != .none


### PR DESCRIPTION
Without it, it was not visible exactly what the app / DFU was doing when the Erase App Settings caused the issue in older versions of firmware. That has been addressed of course, but still, improving visibility of what the app is doing is a good thing for now and the future.