### PR TITLE
Fix: BasicManager's echo() returns an Error if the message is too long

### DIFF
--- a/Source/Managers/BasicManager.swift
+++ b/Source/Managers/BasicManager.swift
@@ -17,6 +17,8 @@ public class BasicManager: McuManager {
     
     // MARK: - Constants
 
+    public static let MAX_ECHO_MESSAGE_SIZE_BYTES = 2475
+    
     enum ID: UInt8 {
         case Reset = 0
     }
@@ -34,5 +36,19 @@ public class BasicManager: McuManager {
     /// - parameter callback: The response callback with a ``McuMgrResponse``.
     public func eraseAppSettings(callback: @escaping McuMgrCallback<McuMgrResponse>) {
         send(op: .write, commandId: ID.Reset, payload: [:], timeout: 1, callback: callback)
+    }
+}
+
+// MARK: - BasicManagerError
+
+enum BasicManagerError: Hashable, Error, LocalizedError {
+    
+    case echoMessageOverTheLimit(_ messageSize: Int)
+    
+    var errorDescription: String? {
+        switch self {
+        case .echoMessageOverTheLimit(let messageSize):
+            return "Echo Message of \(messageSize) bytes in size is over the limit of \(BasicManager.MAX_ECHO_MESSAGE_SIZE_BYTES) bytes."
+        }
     }
 }

--- a/Source/Managers/DefaultManager.swift
+++ b/Source/Managers/DefaultManager.swift
@@ -42,6 +42,15 @@ public class DefaultManager: McuManager {
     /// - parameter callback: The response callback.
     public func echo(_ echo: String, callback: @escaping McuMgrCallback<McuMgrEchoResponse>) {
         let payload: [String:CBOR] = ["d": CBOR.utf8String(echo)]
+        
+        let echoPacket = McuManager.buildPacket(scheme: transporter.getScheme(), op: .write,
+                                                flags: 0, group: McuMgrGroup.default.uInt16Value,
+                                                sequenceNumber: 0, commandId: ID.Echo, payload: payload)
+        
+        guard echoPacket.count <= BasicManager.MAX_ECHO_MESSAGE_SIZE_BYTES else {
+            callback(nil, BasicManagerError.echoMessageOverTheLimit(echoPacket.count))
+            return
+        }
         send(op: .write, commandId: ID.Echo, payload: payload, callback: callback)
     }
     


### PR DESCRIPTION
There's a limit to the size of the echo message, which is 2475 bytes, package size (not payload - tested). If the message is over this limit, the firmware device will just not reply - wish the behaviour was different, but it's not. So, we provide a helpful error message that returns quickly rather than waiting for a timeout Error.