### PR TITLE
Fix: When uploading offset 0 of any Image, we need to wait more before triggering a Timeout

### DIFF
--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -76,7 +76,7 @@ public class ImageManager: McuManager {
             
             // When uploading offset 0, we might trigger an erase on the firmware's end.
             // Hence, the longer timeout.
-            uploadTimeoutInSeconds = 20
+            uploadTimeoutInSeconds = McuManager.DEFAULT_SEND_TIMEOUT_SECONDS
         } else {
             uploadTimeoutInSeconds = 1
         }

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -32,7 +32,7 @@ open class McuManager {
     /// If a specific Timeout is not set, the number of seconds that will be
     /// allowed to elapse before a send request is considered to have failed
     /// due to a timeout if no response is received.
-    public static let DEFAULT_SEND_TIMEOUT_SECONDS = 30
+    public static let DEFAULT_SEND_TIMEOUT_SECONDS = 40
     
     //**************************************************************************
     // MARK: Properties
@@ -92,9 +92,9 @@ open class McuManager {
             atLevel: .verbose)
         let packetSequenceNumber = nextSequenceNumber
         let packetData = McuManager.buildPacket(scheme: transporter.getScheme(), op: op,
-                                                   flags: flags, group: group.uInt16Value,
-                                                   sequenceNumber: packetSequenceNumber,
-                                                   commandId: commandId, payload: payload)
+                                                flags: flags, group: group.uInt16Value,
+                                                sequenceNumber: packetSequenceNumber,
+                                                commandId: commandId, payload: payload)
         let _callback: McuMgrCallback<T> = { [weak self] (response, error) -> Void in
             guard let self = self else {
                 callback(response, error)


### PR DESCRIPTION
This is because writing a new Image might trigger an erase on the firmware side, which could take a few seconds. Also, note that even if we've set '20' seconds as the timeout number, the total timeout time will probably be closer to 60, because the BleTransport has 3 automatic retries unless an error is encountered.

Fixes Issue https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/52#issuecomment-1479580347