### PR TITLE
Support for 'match' value in Image Upload Response

### DIFF
--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -356,6 +356,14 @@ public class ImageManager: McuManager {
             self.cancelUpload(error: error)
             return
         }
+        
+        // If response includes 'match' value, it should be true.
+        // Else, we assume everything is OK.
+        guard response?.match ?? true else {
+            self.cancelUpload(error: ImageUploadError.offsetMismatch)
+            return
+        }
+        
         // Make sure the image data is set.
         guard let currentImageData = self.imageData, let images = self.uploadImages else {
             self.cancelUpload(error: ImageUploadError.invalidData)
@@ -555,6 +563,8 @@ public enum ImageUploadError: Error {
     case invalidPayload
     /// Image Data is nil.
     case invalidData
+    /// Response payload reports package offset does not match expected value.
+    case offsetMismatch
     
     case invalidUploadSequenceNumber(McuSequenceNumber)
     /// McuMgrResponse contains a error return code.
@@ -569,6 +579,8 @@ extension ImageUploadError: LocalizedError {
             return "Response payload values do not exist."
         case .invalidData:
             return "Image data is nil."
+        case .offsetMismatch:
+            return "Response payload reports package offset does not match expected value."
         case .invalidUploadSequenceNumber(let sequenceNumber):
             return "Received Response for Unknown Sequence Number \(sequenceNumber)."
         case .mcuMgrErrorCode(let code):

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -450,10 +450,16 @@ public class McuMgrUploadResponse: McuMgrResponse {
     
     /// Offset to send the next packet of image data from.
     public var off: UInt64?
+    public var match: Bool?
     
     public required init(cbor: CBOR?) throws {
         try super.init(cbor: cbor)
-        if case let CBOR.unsignedInt(off)? = cbor?["off"] {self.off = off}
+        if case let CBOR.unsignedInt(off)? = cbor?["off"] {
+            self.off = off
+        }
+        if case let CBOR.boolean(match)? = cbor?["match"] {
+            self.match = match
+        }
     }
 }
 


### PR DESCRIPTION
If it's present and it returns 'false', then we need to throw an error because we're not matching the offset the device is expecting.