### PR TITLE
Updated Minimum Valid MTU Size to 73 bytes

### DIFF
--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -205,7 +205,7 @@ open class McuManager {
         return RFC3339DateFormatter.string(from: date)
     }
     
-    static let ValidMTURange = 23...1024
+    static let ValidMTURange = 73...1024
     
     public func setMtu(_ mtu: Int) throws  {
         guard Self.ValidMTURange.contains(mtu) else {


### PR DESCRIPTION
When we updated the library to send the Full SHA, this ballooned the minimum size of the MTU, otherwise the packet is bigger than the MTU, so no Data can be sent. This we've seen as crashes out in the wild in nRF Connect.