### PR TITLE
Fix for invalid lock timeout on Connection when sending a Packet

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -311,7 +311,7 @@ extension McuMgrBleTransport: McuMgrTransport {
             }
             
             // Wait for the setup process to complete.
-            let result = connectionLock.block(timeout: DispatchTime.now() + .seconds(timeoutInSeconds))
+            let result = connectionLock.block(timeout: DispatchTime.now() + .seconds(McuMgrBleTransportConstant.CONNECTION_TIMEOUT))
             
             switch result {
             case let .failure(error):


### PR DESCRIPTION
McuMgrBleTransport sets a connection lock with a timeout of 20 seconds, but then when it's time to wait for said lock, it waits for just a second, which might not be enough, causing a timeout, but then, the next time a packet is attempted (due to the min number of retries being larger than 1), the connection might be set because a bit more time was needed. This might mean the Mcu Mgr Parameters Request might fail just because the target firmware device was not super fast or BLE traffic was high.