### PR TITLE
Extended 'Fast Timeout' for Commands

### DIFF
--- a/Source/Managers/BasicManager.swift
+++ b/Source/Managers/BasicManager.swift
@@ -35,7 +35,7 @@ public class BasicManager: McuManager {
     ///
     /// - parameter callback: The response callback with a ``McuMgrResponse``.
     public func eraseAppSettings(callback: @escaping McuMgrCallback<McuMgrResponse>) {
-        send(op: .write, commandId: ID.Reset, payload: [:], timeout: 1, callback: callback)
+        send(op: .write, commandId: ID.Reset, payload: [:], timeout: McuManager.FAST_TIMEOUT, callback: callback)
     }
 }
 

--- a/Source/Managers/DefaultManager.swift
+++ b/Source/Managers/DefaultManager.swift
@@ -111,7 +111,7 @@ public class DefaultManager: McuManager {
     ///
     /// - parameter callback: The response callback.
     public func params(callback: @escaping McuMgrCallback<McuMgrParametersResponse>) {
-        send(op: .read, commandId: ID.McuMgrParameters, payload: nil, timeout: 1, callback: callback)
+        send(op: .read, commandId: ID.McuMgrParameters, payload: nil, timeout: McuManager.FAST_TIMEOUT, callback: callback)
     }
 }
 

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -77,7 +77,7 @@ public class ImageManager: McuManager {
             // Hence, the longer timeout.
             uploadTimeoutInSeconds = McuManager.DEFAULT_SEND_TIMEOUT_SECONDS
         } else {
-            uploadTimeoutInSeconds = 1
+            uploadTimeoutInSeconds = McuManager.FAST_TIMEOUT
         }
         send(op: .write, commandId: ImageID.Upload, payload: payload, timeout: uploadTimeoutInSeconds,
              callback: callback)

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -33,6 +33,9 @@ open class McuManager {
     /// allowed to elapse before a send request is considered to have failed
     /// due to a timeout if no response is received.
     public static let DEFAULT_SEND_TIMEOUT_SECONDS = 40
+    /// This is the default time to wait for a command to be sent, executed
+    /// and received (responded to) by the firmware on the other end.
+    public static let FAST_TIMEOUT = 2
     
     //**************************************************************************
     // MARK: Properties


### PR DESCRIPTION
Previously, the default wait time for commands was 1 second, which in theory should be enough, but on firmware devices under stress (older chips) it might be too strict. So we've doubled the amount. Which could make transfers slower when a retry is required, but we can't have it all.