### PR TITLE
Fix for SMP Reassembly + Pipelining not sending chunks in order

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransportWriteState.swift
+++ b/Source/Bluetooth/McuMgrBleTransportWriteState.swift
@@ -19,7 +19,8 @@ final class McuMgrBleTransportWriteState {
     
     // MARK: - Private Properties
     
-    private let lockingQueue = DispatchQueue(label: "McuMgrBleTransportWriteState")
+    private let lockingQueue = DispatchQueue(label: "McuMgrBleTransportWriteState",
+                                             qos: .userInitiated)
     
     private var state = [UInt8: McuMgrBleTransportWrite]()
     
@@ -37,6 +38,10 @@ final class McuMgrBleTransportWriteState {
             assert(self.state[sequenceNumber]?.writeLock.isOpen ?? true)
             self.state[sequenceNumber] = (sequenceNumber: sequenceNumber, writeLock: lock, nil, nil)
         }
+    }
+    
+    func sharedLock(_ writeClosure: @escaping () -> Void) {
+        lockingQueue.async { writeClosure() }
     }
     
     func received(sequenceNumber: McuSequenceNumber, data: Data) {


### PR DESCRIPTION
Before this change, Data chunks for each Sequence Header could be interleaved between them, because the writes were made in parallel. The theory is that CB Peripheral was buffering the writes per thread and that's how, until now, McuMgr DFU has been working. But this should alleviate issues.