### PR TITLE
Fix: Wait for Write Without Response Buffer

### DIFF
--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -35,7 +35,7 @@ open class McuManager {
     public static let DEFAULT_SEND_TIMEOUT_SECONDS = 40
     /// This is the default time to wait for a command to be sent, executed
     /// and received (responded to) by the firmware on the other end.
-    public static let FAST_TIMEOUT = 2
+    public static let FAST_TIMEOUT = 5
     
     //**************************************************************************
     // MARK: Properties


### PR DESCRIPTION
Core Bluetooth has a buffer when we give it Data to send / write with the writeValue API. Each Device has a different limit, but after 10 packets for sure, could be more, the API stops 'adding' or accepting Data, and so doesn't send it. There are other solutions for this, like a proper API callback for when you can send. We opted for a 'spinlock' solution of checking and waiting whether we can send. But we don't do it packet by packet, because it's too slow and CoreBluetooth is going to tell us every time that we should wait. So instead, we set a target of 10 writes, we wait for as many Connection Intervals as is necessary, and then keep writing. We get decent speed I'd say, and previous working use cases for DFU should not be affected.