### PR TITLE
Legibility change: We now log Data as two-byte spaced at Ble Transport Level

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -367,7 +367,7 @@ extension McuMgrBleTransport: McuMgrTransport {
                     return
                 }
                 if let chunk {
-                    self?.log(msg: "-> [Seq: \(sequenceNumber)] \(chunk.hexEncodedString(options: .prepend0x)) (\(chunk.count) bytes)", atLevel: .debug)
+                    self?.log(msg: "-> [Seq: \(sequenceNumber)] \(chunk.hexEncodedString(options: [.upperCase, .twoByteSpacing])) (\(chunk.count) bytes)", atLevel: .debug)
                 }
             }
         } else {
@@ -383,7 +383,7 @@ extension McuMgrBleTransport: McuMgrTransport {
                     return
                 }
                 if let data {
-                    self?.log(msg: "-> [Seq: \(sequenceNumber)] \(data.hexEncodedString(options: .prepend0x)) (\(data.count) bytes)", atLevel: .debug)
+                    self?.log(msg: "-> [Seq: \(sequenceNumber)] \(data.hexEncodedString(options: [.upperCase, .twoByteSpacing])) (\(data.count) bytes)", atLevel: .debug)
                 }
             }
         }
@@ -401,8 +401,8 @@ extension McuMgrBleTransport: McuMgrTransport {
         case .success:
             guard let returnData = writeState[sequenceNumber]?.chunk else {
                 return .failure(McuMgrTransportError.badHeader)
-            }            
-            log(msg: "<- [Seq: \(sequenceNumber)] \(returnData.hexEncodedString(options: .prepend0x)) (\(returnData.count) bytes)", atLevel: .debug)
+            }
+            log(msg: "<- [Seq: \(sequenceNumber)] \(returnData.hexEncodedString(options: [.upperCase, .twoByteSpacing])) (\(returnData.count) bytes)", atLevel: .debug)
             return .success(returnData)
         }
     }

--- a/Source/Extensions/Data+McuManager.swift
+++ b/Source/Extensions/Data+McuManager.swift
@@ -37,24 +37,30 @@ internal extension Data {
     
     struct HexEncodingOptions: OptionSet {
         public let rawValue: Int
+        
         public static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
-        public static let space = HexEncodingOptions(rawValue: 1 << 1)
+        public static let byteSpacing = HexEncodingOptions(rawValue: 1 << 1)
         public static let prepend0x = HexEncodingOptions(rawValue: 1 << 2)
+        public static let twoByteSpacing = HexEncodingOptions(rawValue: 1 << 3)
+        
         public init(rawValue: Int) {
             self.rawValue = rawValue
         }
     }
     
     func hexEncodedString(options: HexEncodingOptions = []) -> String {
-        if isEmpty {
-            return "0 bytes"
-        }
+        guard !isEmpty else { return "0 bytes" }
+        
         var format = options.contains(.upperCase) ? "%02hhX" : "%02hhx"
-        if options.contains(.space) {
+        if options.contains(.byteSpacing) {
             format.append(" ")
         }
         let prefix = options.contains(.prepend0x) ? "0x" : ""
-        return prefix + map { String(format: format, $0) }.joined()
+        var body = map { String(format: format, $0) }.joined()
+        if options.contains(.twoByteSpacing) {
+            body = body.inserting(separator: " ", every: 4)
+        }
+        return prefix + body
     }
     
     // MARK: - Fragmentation

--- a/Source/Extensions/String+McuManager.swift
+++ b/Source/Extensions/String+McuManager.swift
@@ -25,6 +25,18 @@ internal extension String {
             return self
         }
     }
+    
+    func inserting(separator: String, every n: Int) -> String {
+        var result: String = ""
+        let characters = Array(self)
+        stride(from: 0, to: characters.count, by: n).forEach {
+            result += String(characters[$0..<min($0 + n, characters.count)])
+            if $0 + n < characters.count {
+                result += separator
+            }
+        }
+        return result
+    }
 }
 
 // MARK: - StringInterpolation


### PR DESCRIPTION
So, instead of reading incoming and outgoing bytes as 0x03000177 we show them as 0300 0177. I think this is easier to read and compare bytes when checking whether something is working as expected or not. It also matches how Apple's Packet Logger (Sniffer) Developer tool shows bytes.