### PR TITLE
Macos support

### DIFF
--- a/Example/Example/Util/McuMgrPackage.swift
+++ b/Example/Example/Util/McuMgrPackage.swift
@@ -19,12 +19,7 @@ public struct McuMgrPackage {
     // MARK: - Init
     
     init(from url: URL) throws {
-        let document = UIDocument(fileURL: url)
-        guard let fileType = document.fileType else {
-            throw McuMgrPackage.Error.notAValidDocument
-        }
-        
-        switch UTI.from(fileType) {
+        switch UTI.forFile(url) {
         case .bin:
             self.images = try Self.extractImageFromBinFile(from: url)
         case .zip:

--- a/Example/Example/Util/UTI.swift
+++ b/Example/Example/Util/UTI.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 import UniformTypeIdentifiers
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
 
 // MARK: - UTI
 
@@ -32,5 +37,18 @@ enum UTI: String, CaseIterable {
         return UTI.allCases.first {
             $0.typeIdentifiers.contains(fileType)
         }
+    }
+    
+    private static func typeOf(_ url: URL) -> String? {
+#if os(macOS)
+        return try? NSWorkspace.shared.type(ofFile: url.path)
+#else
+        let document = UIDocument(fileURL: url)
+        return document.fileType
+#endif
+    }
+    
+    static func forFile(_ file: URL) -> UTI? {
+        return typeOf(file).flatMap({ from($0) })
     }
 }

--- a/iOSMcuManagerLibrary.podspec
+++ b/iOSMcuManagerLibrary.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.swift_versions = ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7"]
 
   s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.13"
 
   s.source_files = "Source/**/*.{swift, h}"
   s.exclude_files = "Source/*.plist"


### PR DESCRIPTION
This PR adds support for macOS when installed with CocoaPods (it is already supported in SwiftPM) and also supports macOS in `McuMgrPackage`