### PR TITLE
Fix for bad default Filesystem Mount Point

### DIFF
--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -9,7 +9,10 @@ import iOSMcuManagerLibrary
 
 class FilesController: UITableViewController {
     static let partitionKey = "partition"
-    static let defaultPartition = "lfs" // https://github.com/ARMmbed/littlefs
+    /**
+    [LittleFS GitHub Project](https://github.com/ARMmbed/littlefs)
+     */
+    static let defaultPartition = "lfs1"
     
     @IBOutlet weak var connectionStatus: ConnectionStateLabel!
     

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -382,7 +382,7 @@ extension McuMgrReturnCode: CustomStringConvertible {
         case .timeout:
             return "Timeout (RC: \(rawValue))"
         case .noEntry:
-            return "No Entry (RC: \(rawValue))"
+            return "No Entry (RC: \(rawValue)). For Filesystem Operations, Does Your Mounting Point Match Your Target Firmware / Device?"
         case .badState:
             return "Bad State (RC: \(rawValue))"
         case .responseIsTooLong:


### PR DESCRIPTION
This was changed in Zephyr / McuMgr SDK to /lfs1 from the previous /lfs. User can edit this in Example app by tapping on 'Edit' on the upper-right corner, but they shouldn't need to do this to get this feature to work with a fresh DK from one of our own samples. Error Code has also been updated to better inform users.