### PR TITLE
Internal Structures Support for targeting specific Image Slot

### DIFF
--- a/Example/Example/Util/McuMgrPackage.swift
+++ b/Example/Example/Util/McuMgrPackage.swift
@@ -31,18 +31,23 @@ public struct McuMgrPackage {
     
     // MARK: - API
     
-    static func imageName(at index: Int) -> String {
-        switch index {
-        case 0: return "App Core"
-        case 1: return "Net Core"
-        default: return "Image \(index)"
+    func imageName(at index: Int) -> String {
+        let coreName: String
+        switch images[index].image {
+        case 0: 
+            coreName = "App Core"
+        case 1: 
+            coreName = "Net Core"
+        default: 
+            coreName = "Image \(index)"
         }
+        return "\(coreName) Slot \(images[index].slot)"
     }
     
     func sizeString() -> String {
         var sizeString = ""
         for (i, image) in images.enumerated() {
-            sizeString += "\(image.data.count) bytes (\(Self.imageName(at: i)))"
+            sizeString += "\(image.data.count) bytes (\(imageName(at: i)))"
             guard i != images.count - 1 else { continue }
             sizeString += "\n"
         }
@@ -54,7 +59,7 @@ public struct McuMgrPackage {
         for (i, image) in images.enumerated() {
             let hash = try McuMgrImage(data: image.data).hash
             let hashString = hash.hexEncodedString(options: .upperCase)
-            result += "0x\(hashString.prefix(6))...\(hashString.suffix(6)) (\(Self.imageName(at: i)))"
+            result += "0x\(hashString.prefix(6))...\(hashString.suffix(6)) (\(imageName(at: i)))"
             guard i != images.count - 1 else { continue }
             result += "\n"
         }
@@ -120,7 +125,7 @@ fileprivate extension McuMgrPackage {
                 throw McuMgrPackage.Error.manifestImageNotFound
             }
             let imageData = try Data(contentsOf: imageURL)
-            return (manifestFile.image, imageData)
+            return ImageManager.Image(manifestFile, data: imageData)
         }
         try unzippedURLs.forEach { url in
             try fileManager.removeItem(at: url)

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -8,8 +8,40 @@ import Foundation
 import CoreBluetooth
 import SwiftCBOR
 
+// MARK: - ImageManager
+
 public class ImageManager: McuManager {
-    public typealias Image = (image: Int, data: Data)
+    
+    // MARK: Image
+    
+    public struct Image {
+        public let image: Int
+        public let slot: Int
+        public let data: Data
+        
+        /**
+         So far, only DirectXIP would target `slot` 0 (Primary). So if not specifically
+         stated, all of the previous code / modes target `slot` 1 (Secondary). Hence,
+         why that's the default.
+         */
+        public init(image: Int, slot: Int = 1, data: Data) {
+            self.image = image
+            self.slot = slot
+            self.data = data
+        }
+        
+        public init(_ manifest: McuMgrManifest.File, data: Data) {
+            self.image = manifest.image
+            self.slot = manifest.slot
+            self.data = data
+        }
+        
+        internal init(_ image: FirmwareUpgradeImage) {
+            self.image = image.image
+            self.slot = image.slot
+            self.data = image.data
+        }
+    }
     
     override class var TAG: McuMgrLogCategory { .image }
     


### PR DESCRIPTION
Before Direct XIP, active slot was always assumed to be 0, or Primary. And upload or target slot was always 1, or Secondary. That's not the case, so we need a way to track which slot is the target. This represents ongoing work.