### PR TITLE
Fix for bad default 'slot' value

### DIFF
--- a/Source/McuMgrManifest.swift
+++ b/Source/McuMgrManifest.swift
@@ -56,7 +56,7 @@ extension McuMgrManifest {
         public let modTime: Int
         public let mcuBootVersion: String?
         /**
-         If not present when parsing a Manifest from .json, slot 0 (primary)
+         If not present when parsing a Manifest from .json, slot 1 (Secondary)
          is assumed as the binary's target.
          */
         public let slot: Int
@@ -111,7 +111,7 @@ extension McuMgrManifest {
             loadAddress = try values.decode(Int.self, forKey: .loadAddress)
             
             let slotString = try? values.decode(String.self, forKey: .slot)
-            slot = Int(slotString ?? "") ?? 0
+            slot = Int(slotString ?? "") ?? 1
             
             let version = try? values.decode(String.self, forKey: .mcuBootVersion)
             _mcuBootXipVersion = try? values.decode(String.self, forKey: ._mcuBootXipVersion)


### PR DESCRIPTION
The default slot should be 1, aka "secondary". Because except for DirectXIP, we always upload to the Secondary slot when doing DFU.