### PR TITLE
Initial Direct XIP Support + Revert of Default Image Slot Value (back to 0)

### DIFF
--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -20,11 +20,11 @@ public class ImageManager: McuManager {
         public let data: Data
         
         /**
-         So far, only DirectXIP would target `slot` 0 (Primary). So if not specifically
-         stated, all of the previous code / modes target `slot` 1 (Secondary). Hence,
-         why that's the default.
+         All of the previous code / modes target `slot` 0 (Primary) as where they
+         want the image uploaded, so that's the default. Only DirectXIP would
+         target `slot` 1 (Secondary).
          */
-        public init(image: Int, slot: Int = 1, data: Data) {
+        public init(image: Int, slot: Int = 0, data: Data) {
             self.image = image
             self.slot = slot
             self.data = data
@@ -366,16 +366,14 @@ public class ImageManager: McuManager {
     private lazy var uploadCallback: McuMgrCallback<McuMgrUploadResponse> = {
         [weak self] (response: McuMgrUploadResponse?, error: Error?) in
         // Ensure the manager is not released.
-        guard let self = self else {
-            return
-        }
+        guard let self else { return }
         
         if #available(iOS 10.0, watchOS 3.0, *) {
             dispatchPrecondition(condition: .onQueue(.main))
         }
         
         // Check for an error.
-        if let error = error {
+        if let error {
             if case let McuMgrTransportError.insufficientMtu(newMtu) = error {
                 do {
                     try self.setMtu(newMtu)
@@ -402,7 +400,7 @@ public class ImageManager: McuManager {
             return
         }
         // Make sure the response is not nil.
-        guard let response = response else {
+        guard let response else {
             self.cancelUpload(error: ImageUploadError.invalidPayload)
             return
         }

--- a/Source/McuMgrManifest.swift
+++ b/Source/McuMgrManifest.swift
@@ -56,8 +56,10 @@ extension McuMgrManifest {
         public let modTime: Int
         public let mcuBootVersion: String?
         /**
-         If not present when parsing a Manifest from .json, slot 1 (Secondary)
-         is assumed as the binary's target.
+         If not present when parsing a Manifest from .json, slot 0 (Primary)
+         is assumed as the binary's target. If no DirectXIP is involved, it
+         might be uploaded to slot 1 and then swapped, but the assumed target
+         is the Primary slot.
          */
         public let slot: Int
         public let type: String
@@ -111,7 +113,7 @@ extension McuMgrManifest {
             loadAddress = try values.decode(Int.self, forKey: .loadAddress)
             
             let slotString = try? values.decode(String.self, forKey: .slot)
-            slot = Int(slotString ?? "") ?? 1
+            slot = Int(slotString ?? "") ?? 0
             
             let version = try? values.decode(String.self, forKey: .mcuBootVersion)
             _mcuBootXipVersion = try? values.decode(String.self, forKey: ._mcuBootXipVersion)

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -379,7 +379,7 @@ public final class AppInfoResponse: McuMgrResponse {
 
 public final class BootloaderInfoResponse: McuMgrResponse {
     
-    public enum Mode: Int, CustomStringConvertible {
+    public enum Mode: Int, Codable, CustomStringConvertible {
         case Unknown = -1
         case SingleApplication = 0
         case SwapUsingScratch = 1


### PR DESCRIPTION
This commit represents the first time we were able to upload Direct XIP without having to stop the debugger, check something, modify something in the code, etc. Now, this doesn't mean that it's finished - I believe it can be made a lot tidier. But it's closer.

As for the revert on the Default Image Slot value, if we leave Direct XIP aside, what we want every time is for the image to be in slot 0. That's what our comparison for 'is this already uploaded?' is against. Hence, why the correct value, I think now after going back and forth a couple of times, is zero for how we've been doing things up until now.