### PR TITLE
Fix: McuMgr Parameters & Bootloader Info are Independent

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -320,8 +320,7 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
                 self.log(msg: "Cancelling 'Erase App Settings' since device capabilities are not supported.", atLevel: .info)
                 self.configuration.eraseAppSettings = false
             }
-            self.log(msg: "Skipping over 'Bootloader Info' step since device capabilities (McuMgr Parameters) are not supported.", atLevel: .info)
-            self.validate() // Continue Upload
+            self.bootloaderInfo() // Continue to Bootloader Info.
             return
         }
         


### PR DESCRIPTION
Either, Both or none could be present. If one fails, there's no relation to the other, as we were assuming previously.