### PR TITLE
Added status, crc32, sha256 and closeAll APIs to FileSystemManager

### DIFF
--- a/Source/McuMgrLogDelegate.swift
+++ b/Source/McuMgrLogDelegate.swift
@@ -39,17 +39,17 @@ public enum McuMgrLogLevel: Int {
 
 /// The log category indicates the component that created the log entry.
 public enum McuMgrLogCategory: String {
-    case transport = "Transport"
-    case Settings  = "SettingsManager"
-    case crash     = "CrashManager"
-    case `default` = "DefaultManager"
-    case fs        = "FSManager"
-    case image     = "ImageManager"
-    case log       = "LogManager"
-    case runTest   = "RunTestManager"
-    case stats     = "StatsManager"
-    case dfu       = "DFU"
-    case basic     = "BasicManager"
+    case transport         = "Transport"
+    case Settings          = "SettingsManager"
+    case crash             = "CrashManager"
+    case `default`         = "DefaultManager"
+    case FileSystemManager = "FileSystemManager"
+    case image             = "ImageManager"
+    case log               = "LogManager"
+    case runTest           = "RunTestManager"
+    case stats             = "StatsManager"
+    case dfu               = "DFU"
+    case basic             = "BasicManager"
 }
 
 /// The Logger delegate.

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -614,6 +614,75 @@ public class McuMgrFsDownloadResponse: McuMgrResponse {
     }
 }
 
+public class McuMgrFilesystemCrc32Response: McuMgrResponse {
+    
+    // Type of hash/checksum that was performed.
+    public var type: String?
+    // Offset that checksum calculation started at
+    public var off: UInt64?
+    // Length of input data used for hash/checksum generation (in bytes)
+    public var len: UInt64?
+    // IEEE CRC32 checksum (uint32 represented as type long)
+    public var output: UInt64?
+    
+    public required init(cbor: CBOR?) throws {
+        try super.init(cbor: cbor)
+        if case let CBOR.utf8String(type)? = cbor?["type"] {
+            self.type = type
+        }
+        if case let CBOR.unsignedInt(off)? = cbor?["off"] {
+            self.off = off
+        }
+        if case let CBOR.unsignedInt(len)? = cbor?["len"] {
+            self.len = len
+        }
+        if case let CBOR.unsignedInt(output)? = cbor?["output"] {
+            self.output = output
+        }
+    }
+}
+
+public class McuMgrFilesystemSha256Response: McuMgrResponse {
+    
+    // Type of hash/checksum that was performed.
+    public var type: String?
+    // Offset that checksum calculation started at.
+    public var off: UInt64?
+    // Length of input data used for hash/checksum generation (in bytes)
+    public var len: UInt64?
+    // 32-byte SHA256 (Secure Hash Algorithm)
+    public var output: [UInt8]?
+    
+    public required init(cbor: CBOR?) throws {
+        try super.init(cbor: cbor)
+        if case let CBOR.utf8String(type)? = cbor?["type"] {
+            self.type = type
+        }
+        if case let CBOR.unsignedInt(off)? = cbor?["off"] {
+            self.off = off
+        }
+        if case let CBOR.unsignedInt(len)? = cbor?["len"] {
+            self.len = len
+        }
+        if case let CBOR.byteString(output)? = cbor?["output"] {
+            self.output = output
+        }
+    }
+}
+
+public class McuMgrFilesystemStatusResponse: McuMgrResponse {
+    
+    /// The length of the file.
+    public var len: UInt64?
+    
+    public required init(cbor: CBOR?) throws {
+        try super.init(cbor: cbor)
+        if case let CBOR.unsignedInt(len)? = cbor?["len"] {
+            self.len = len
+        }
+    }
+}
+
 //******************************************************************************
 // MARK: Logs Responses
 //******************************************************************************


### PR DESCRIPTION
These were missing from the previous release of iOS-McuMgrLibrary. Also, interesting wrinkle here: none of this is tested :( So, if you're swearing at this code via git-blame yes, blame me. I wrote a full frontend to implement and test Pipelining for FS Upload, but I'm not doing that for these.