### PR TITLE
Randomizing initial sequence number to lower the risk of collision

### DIFF
--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -63,7 +63,7 @@ open class McuManager {
     
     /// Each 'send' command gets its own Sequence Number, which we rotate
     /// within the bounds of an unsigned UInt8 [0...255].
-    private var nextSequenceNumber: McuSequenceNumber = 0
+    private var nextSequenceNumber: McuSequenceNumber = UInt8.random(in: 0...255)
     
     /**
      Sequence Number Response ReOrder Buffer


### PR DESCRIPTION
There's a general issue in SMP protocol and this Mcu Manager implementation. The 8-byte header, which contains the SEQ field, is built by the manager before sending to the transport. However, SEQ should be a part of transport layer, as it's only purpose is to match request with the response to return to the manager.

However, as it is possible to have multiple managers, each with own SEQ counter, and they reuse the same transport, it is possible that they start sending messages with the same SEQ more or less at the same time. The transport doesn't like that and asserts on a collision.

To lower the risk of collisions, this PR randomizes the initial value of the SEQ. Each counter is a UInt8 wich rewinds to 0 after reaching max, but it's not common to send multiple commands often. The risk of initial collision, when just after connection several requests are made, goes down from 1 to 1/255^2.