### PR TITLE
Logs now log which Image/Slot/Hash Combination is scheduled to upload

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -196,6 +196,11 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
                 uploadDidFinish()
                 return
             }
+            for image in imagesToUpload {
+                let hash = (try? McuMgrImage(data: image.data).hash)
+                let hashString = hash?.hexEncodedString(options: [.prepend0x, .upperCase]) ?? "(Unknown)"
+                log(msg: "Scheduling Image \(image.image) Slot \(image.slot) Hash \(hashString) for upload", atLevel: .verbose)
+            }
             _ = imageManager.upload(images: imagesToUpload, using: configuration, delegate: self)
         }
     }


### PR DESCRIPTION
This is during the handover process between FirmwareUpgradeManager to ImageManager. When the first gives the second the set of images that are needed to be sent. It doesn't fix anything, it's just for me to help me understand I'm not losing my mind.