### PR TITLE
Fix: Bad Confirm Callback Logic affecting Multi-Image DFU

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -699,10 +699,14 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
                         continue
                     }
                     
-                    if image.confirmed && !image.confirmSent {
-                        self.confirm(image)
-                    } else {
-                        self.fail(error: FirmwareUpgradeError.unknown("Image \(targetSlot.image) Slot \(targetSlot.slot) is not in a Permanent state after sending Confirm Command."))
+                    
+                    if !image.confirmed {
+                        if image.confirmSent {
+                            self.fail(error: FirmwareUpgradeError.unknown("Image \(targetSlot.image) Slot \(targetSlot.slot) is not in a Permanent state after sending Confirm Command."))
+                        } else {
+                            self.confirm(image)
+                            self.mark(image, as: \.confirmSent)
+                        }
                     }
                     return
                 }


### PR DESCRIPTION
The 'if' was basically a pit into hell of throwing an Error. My God did I have to go far to chase this one.