### PR TITLE
Fix: Ignore FirmwareUpgradeManagerConfiguration's 'estimatedSwapTime'…

### DIFF
--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -407,6 +407,15 @@ public final class BootloaderInfoResponse: McuMgrResponse {
         case directXIPWithRevert = 5
         case RAMLoader = 6
         
+        /**
+         Intended for use cases where it's not important to know what kind of DirectXIP
+         variant this Bootloader Mode might represent, but instead, whether it's
+         DirectXIP or not.
+         */
+        public var isDirectXIP: Bool {
+            return self == .directXIPNoRevert || self == .directXIPWithRevert
+        }
+        
         public var debugDescription: String {
             switch self {
             case .unknown:


### PR DESCRIPTION
… for DirectXIP Bootloader

As we explained in updated comments, as well as one can do that when coding and waiting for a Scary Fast Apple Event, under DirectXIP Bootloader Mode there's no swap time at all. So we can just ignore any reset time.