### PR TITLE
McuMgr ROB (Re-Order) Buffer can now Log Directly

### DIFF
--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -127,6 +127,7 @@ open class McuManager {
             }
         }
         
+        robBuffer.logDelegate = logDelegate
         robBuffer.expectingValue(for: packetSequenceNumber)
         send(data: packetData, timeout: timeout, callback: _callback)
         rotateSequenceNumber()

--- a/Source/McuMgrROBBuffer.swift
+++ b/Source/McuMgrROBBuffer.swift
@@ -29,6 +29,8 @@ public struct McuMgrROBBuffer<Key: Hashable & Comparable, Value> {
     
     // MARK: API
     
+    public weak var logDelegate: McuMgrLogDelegate?
+    
     subscript(_ key: Key) -> Value? {
         buffer[key]
     }
@@ -53,9 +55,8 @@ public struct McuMgrROBBuffer<Key: Hashable & Comparable, Value> {
                 pendingKeys.removeFirst()
             } else {
                 pendingKeys.remove(at: i)
-                if #available(iOS 10.0, *) {
-                    os_log("%{public}@", log: .default, type: .info, "Received key \(key) OoO (Out of Order).")
-                }
+                logDelegate?.log("Received key \(key) OoO (Out of Order).", ofCategory: .transport,
+                                 atLevel: .debug)
             }
             return valueReceivedInOrder
         }


### PR DESCRIPTION
By raising this Log up the food chain, apps using the library can see the information logged by this low-level component.  I needed to see this to debug the Amazon Sidewalk template we're chasing.