### PR TITLE
BLE Transport Layer Re-Order Buffer Improvements

### DIFF
--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -107,7 +107,7 @@ open class McuManager {
             }
             
             do {
-                guard try self.robBuffer.receivedInOrder((response, error), for: packetSequenceNumber) else { return }
+                guard try self.robBuffer.received((response, error), for: packetSequenceNumber) else { return }
                 try self.robBuffer.deliver { responseSequenceNumber, response in
                     let responseResult = response as? (T?, (any Error)?)
                     if let response = responseResult?.0 {
@@ -128,7 +128,7 @@ open class McuManager {
         }
         
         robBuffer.logDelegate = logDelegate
-        robBuffer.expectingValue(for: packetSequenceNumber)
+        robBuffer.enqueueExpectation(for: packetSequenceNumber)
         send(data: packetData, timeout: timeout, callback: _callback)
         rotateSequenceNumber()
     }


### PR DESCRIPTION
The ROB (Re-Order Buffer) now effectively returns back values when it's not missing the intervening numbers. This should speed-up DFU speed in situations where sequence numbers are returned out of order. It could be argued this is not necessary and that the need for re-ordering responses is indeed a red-herring for other DFU Library issues, which is why the Buffer can now log. So if the ROB Buffer is indeed reordering responses, they should be visible on the logs, hence providing information about a potential cause for an issue.