### PR TITLE
Don't override user settings when Mcu Manager Params are not supported

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -333,18 +333,6 @@ public class FirmwareUpgradeManager : FirmwareUpgradeController, ConnectionObser
         
         guard error == nil, let response, response.rc != 8 else {
             self.log(msg: "Mcu Manager parameters not supported", atLevel: .warning)
-            if self.configuration.pipeliningEnabled {
-                self.log(msg: "Disabling Pipelining since device capabilities are not supported.", atLevel: .verbose)
-                self.configuration.pipelineDepth = 1
-            }
-            if self.configuration.reassemblyBufferSize > 0 {
-                self.log(msg: "Disabling Reassembly since device capabilities are not supported.", atLevel: .verbose)
-                self.configuration.reassemblyBufferSize = 0
-            }
-            if self.configuration.eraseAppSettings {
-                self.log(msg: "Cancelling 'Erase App Settings' since device capabilities are not supported.", atLevel: .verbose)
-                self.configuration.eraseAppSettings = false
-            }
             self.bootloaderInfo() // Continue to Bootloader Info.
             return
         }


### PR DESCRIPTION
This PR removes overriding user configuration when Mcu Manager Params command is not supported by the device. Apparently, some devices don't support this command, but still allow for pipelining making the DFU much faster.
If the user wants 6 buffers, let's try to use 6 buffers.

For the current nRF54 implementation (which does not support Mcu Mgr Params) the speed increase is 7Kb/s to 40 kB/s (Pixel 7 with Android 14 achieved top speed 71 kB/s with 6 buffers).