### PR TITLE
Allowing sending SUIT files from Image/Advanced

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -129,7 +129,7 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
     
     private func setPipelineDepth() {
         let alertController = UIAlertController(title: "Number of buffers", message: nil, preferredStyle: .actionSheet)
-        let values = [2, 3, 4, 5, 6]
+        let values = [2, 3, 4, 5, 6, 7, 8]
         values.forEach { value in
             let title = value == values.first ? "Disabled" : "\(value)"
             alertController.addAction(UIAlertAction(title: title, style: .default) {

--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -58,7 +58,6 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
     }
     
     @IBAction func start(_ sender: UIButton) {
-        guard canStartUpload() else { return }
         if let package {
             selectMode(for: package)
         } else if let envelope {
@@ -77,8 +76,6 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
     }
     
     @IBAction func resume(_ sender: UIButton) {
-        guard canStartUpload() else { return }
-        
         uploadTimestamp = nil
         uploadImageSize = nil
         dfuManager.resume()
@@ -160,22 +157,6 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
     
     @IBAction func setEraseApplicationSettings(_ sender: UISwitch) {
         dfuManagerConfiguration.eraseAppSettings = sender.isOn
-    }
-    
-    private func canStartUpload() -> Bool {
-        guard dfuManagerConfiguration.pipelineDepth == 1 || dfuManagerConfiguration.byteAlignment != .disabled else {
-            
-            dfuManagerConfiguration.byteAlignment = FirmwareUpgradeConfiguration().byteAlignment
-            dfuByteAlignment.text = "\(dfuManagerConfiguration.byteAlignment)"
-            
-            let alert = UIAlertController(title: "Byte alignment setting changed", message: """
-            Pipelining requires a Byte Alignment setting to be applied, otherwise chunk offsets can't be predicted as more Data is sent.
-            """, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            present(alert)
-            return false
-        }
-        return true
     }
     
     private func selectMode(for package: McuMgrPackage) {

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -30,7 +30,7 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
     @IBOutlet weak var progress: UIProgressView!
     
     @IBAction func selectFirmware(_ sender: UIButton) {
-        let supportedDocumentTypes = ["com.apple.macbinary-archive", "public.zip-archive", "com.pkware.zip-archive"]
+        let supportedDocumentTypes = ["com.apple.macbinary-archive", "public.zip-archive", "com.pkware.zip-archive", "org.ietf.suit", "public.data"]
         let importMenu = UIDocumentMenuViewController(documentTypes: supportedDocumentTypes,
                                                       in: .import)
         importMenu.delegate = self

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -56,7 +56,7 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
     @IBAction func setDfuAlignment(_ sender: UIButton) {
         let alertController = UIAlertController(title: "Byte alignment", message: nil, preferredStyle: .actionSheet)
         ImageUploadAlignment.allCases.forEach { alignmentValue in
-            let text = "\(alertController)"
+            let text = "\(alignmentValue)"
             alertController.addAction(UIAlertAction(title: text, style: .default) {
                 action in
                 self.dfuByteAlignment.text = text

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -40,7 +40,7 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
     
     @IBAction func setNumberOfBuffers(_ sender: UIButton) {
         let alertController = UIAlertController(title: "Number of buffers", message: nil, preferredStyle: .actionSheet)
-        let values = [2, 3, 4, 5, 6]
+        let values = [2, 3, 4, 5, 6, 7, 8]
         values.forEach { value in
             let title = value == values.first ? "Disabled" : "\(value)"
             alertController.addAction(UIAlertAction(title: title, style: .default) {

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -68,7 +68,7 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
     
     @IBAction func setChunkSize(_ sender: Any) {
         let alertController = UIAlertController(title: "Set chunk size", message: "0 means default (MTU size)", preferredStyle: .alert)
-        alertController.addTextField { (textField) in
+        alertController.addTextField { textField in
             textField.placeholder = "\(self.uploadConfiguration.reassemblyBufferSize)"
             textField.keyboardType = .decimalPad
         }


### PR DESCRIPTION
This PR fixes the following issues:
* Allows sending SUIT file from Advanced view on Inage tab. Before it was only possible to send using the Basic view.
* Adds option to select 7 or 8 Mcu Mgr Buffers in both Basic and Advanced view.
* Alignment is printed correctly.
* Byte alignment is not required with pipelining enabled. A validation for that was removed.