### PR TITLE
A flag added to Info.plist that the app supports opening files in place

### DIFF
--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -39,6 +39,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>This application connects to Bluetooth LE devices with SMP service.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>


### PR DESCRIPTION
A warning was shown when submitting the app to AppStore without this flag.