### PR TITLE
Streamlining of start() API for McuMgrSuitEnvelope

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -175,18 +175,14 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
     }
     
     private func startFirmwareUpload(envelope: McuMgrSuitEnvelope) {
-        // -16 is the currently only supported mode cose-alg-sha-256 = -16
-        //
-        // OPTIONAL to implement in SUIT and currently not supported:
-        // cose-alg-shake128 = -18
-        // cose-alg-sha-384 = -43
-        // cose-alg-sha-512 = -44
-        // cose-alg-shake256 = -45
-        guard let supportedDigest = envelope.digest.digests.first(where: {
-            $0.type == -16
-        }) else { return }
+        // sha256 is the currently only supported mode.
+        // The rest are optional to implement in SUIT.
+        guard let sha256Hash = envelope.digest.hash(for: .sha256) else {
+            uploadDidFail(with: McuMgrSuitParseError.supportedAlgorithmNotFound)
+            return
+        }
         uploadWillStart()
-        let image = ImageManager.Image(image: 0, hash: supportedDigest.hash, data: envelope.data)
+        let image = ImageManager.Image(image: 0, hash: sha256Hash, data: envelope.data)
         _ = imageManager.upload(images: [image], using: uploadConfiguration, delegate: self)
     }
 }


### PR DESCRIPTION
The hash part is a bit complicated, so we've made the API better from the library user's perspective. We were on the fence regarding making the modes 'public' and so on, but these things can change specially since SUIT is under heavy development. So if we need to, we can open it up later.