### PR TITLE
Fix for a bad Fix for McuMgrImage Tlv Trailer Offset

### DIFF
--- a/Source/McuMgrImage.swift
+++ b/Source/McuMgrImage.swift
@@ -189,6 +189,9 @@ public class McuMgrImageTlvTrailerEntry {
         
         var offset = offset
         type = data[offset]
+        // Advance 1 byte for read
+        offset += MemoryLayout<UInt8>.size
+        // Advance 1 byte for padding (MIN_SIZE = 4)
         offset += MemoryLayout<UInt8>.size
         length = data.read(offset: offset)
         offset += MemoryLayout<UInt16>.size


### PR DESCRIPTION
We read the value correctly (we think) but the size of the Tlv Trailer Data is 4 bytes, so we need to skip one byte in between.