### PR TITLE
SUIT Bootloader Introduction + Internal-use only McuMgrSuitManifest

### DIFF
--- a/Example/Example/Util/StringConvertibles.swift
+++ b/Example/Example/Util/StringConvertibles.swift
@@ -22,28 +22,3 @@ extension PeripheralState: CustomStringConvertible {
     
 }
 
-extension BootloaderInfoResponse.Mode: CustomStringConvertible {
-    
-    public var description: String {
-        switch self {
-        case .unknown:
-            return "Unknown"
-        case .singleApplication:
-            return "Single application"
-        case .swapUsingScratch:
-            return "Swap using scratch partition"
-        case .overwrite:
-            return "Overwrite (upgrade-only)"
-        case .swapNoScratch:
-            return "Swap without scratch"
-        case .directXIPNoRevert:
-            return "Direct-XIP without revert"
-        case .directXIPWithRevert:
-            return "Direct-XIP with revert"
-        case .RAMLoader:
-            return "RAM Loader"
-        }
-    }
-    
-}
-

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -424,7 +424,24 @@ public final class AppInfoResponse: McuMgrResponse {
 
 public final class BootloaderInfoResponse: McuMgrResponse {
     
-    public enum Mode: Int, Codable, CustomDebugStringConvertible {
+    public enum Bootloader: String, Codable, CustomDebugStringConvertible {
+        case unknown = ""
+        case mcuboot = "MCUboot"
+        case suit = "SUIT"
+        
+        public var description: String {
+            switch self {
+            case .unknown:
+                return "Unknown"
+            case .mcuboot, .suit:
+                return rawValue
+            }
+        }
+        
+        public var debugDescription: String { description }
+    }
+    
+    public enum Mode: Int, Codable, CustomStringConvertible, CustomDebugStringConvertible {
         case unknown = -1
         case singleApplication = 0
         case swapUsingScratch = 1
@@ -443,7 +460,7 @@ public final class BootloaderInfoResponse: McuMgrResponse {
             return self == .directXIPNoRevert || self == .directXIPWithRevert
         }
         
-        public var debugDescription: String {
+        public var description: String {
             switch self {
             case .unknown:
                 return "Unknown"
@@ -463,16 +480,18 @@ public final class BootloaderInfoResponse: McuMgrResponse {
                 return "RAM Loader"
             }
         }
+        
+        public var debugDescription: String { description }
     }
     
-    public var bootloader: String?
+    public var bootloader: Bootloader?
     public var mode: Mode?
     public var noDowngrade: Bool?
     
     public required init(cbor: CBOR?) throws {
         try super.init(cbor: cbor)
-        if case let CBOR.utf8String(bootloader)? = cbor?["bootloader"] {
-            self.bootloader = bootloader
+        if case let CBOR.utf8String(bootloaderString)? = cbor?["bootloader"] {
+            self.bootloader = Bootloader(rawValue: bootloaderString)
         }
         if case let CBOR.unsignedInt(mode)? = cbor?["mode"] {
             self.mode = Mode(rawValue: Int(mode))

--- a/Source/McuMgrSuitEnvelope.swift
+++ b/Source/McuMgrSuitEnvelope.swift
@@ -15,6 +15,11 @@ public struct McuMgrSuitEnvelope {
     public let digest: McuMgrSuitDigest
     public let data: Data
     
+    /**
+     In-Development, therefore, not marked as Public yet.
+     */
+    let manifest: McuMgrSuitManifest?
+    
     // MARK: Init
     
     public init(from url: URL) throws {
@@ -28,6 +33,7 @@ public struct McuMgrSuitEnvelope {
         switch cbor {
         case .tagged(_, let cbor):
             self.digest = try McuMgrSuitDigest(cbor: cbor[0x2])
+            self.manifest = try? McuMgrSuitManifest(cbor: cbor[0x3])
         default:
             throw McuMgrSuitParseError.digestMapNotFound
         }

--- a/Source/McuMgrSuitManifest.swift
+++ b/Source/McuMgrSuitManifest.swift
@@ -1,0 +1,86 @@
+//
+//  McuMgrSuitManifest.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 19/3/24.
+//
+
+import Foundation
+import SwiftCBOR
+
+// MARK: - McuMgrSuitManifest
+
+class McuMgrSuitManifest: CBORMappable {
+    
+    // MARK: Properties
+    
+    private var version: UInt64?
+    private var sequenceNumber: UInt64?
+    private var common: McuMgrSuitCommonStructure?
+    
+    // MARK: Init
+    
+    public required init(cbor: CBOR?) throws {
+        try super.init(cbor: cbor)
+        guard case CBOR.byteString(let byteString)? = cbor,
+              let decodedCbor = try CBOR.decode(byteString) else { return }
+        if case let CBOR.unsignedInt(version)? = decodedCbor[0x01] {
+            self.version = version
+        }
+        if case let CBOR.unsignedInt(sequenceNumber)? = decodedCbor[0x02] {
+            self.sequenceNumber = sequenceNumber
+        }
+        self.common = try? McuMgrSuitCommonStructure(cbor: decodedCbor[0x03])
+    }
+}
+
+// MARK: - McuMgrSuitCommonStructure
+
+class McuMgrSuitCommonStructure: CBORMappable {
+    
+    public var components: [[[UInt8]]]
+    public var sharedSequences: McuMgrSuitSharedSequence?
+    
+    // MARK: Init
+    
+    public required init(cbor: CBOR?) throws {
+        self.components = [[[UInt8]]]()
+        try super.init(cbor: cbor)
+        guard case CBOR.byteString(let byteString)? = cbor,
+              let decodedCbor = try CBOR.decode(byteString) else { return }
+        if case let CBOR.array(components)? = decodedCbor[0x02] {
+            for cborComponent in components {
+                guard case CBOR.array(let componentArray) = cborComponent else { continue }
+                var component = [[UInt8]]()
+                for componentBytes in componentArray {
+                    guard case CBOR.byteString(let decodedBytes) = componentBytes else { continue }
+                    component.append(decodedBytes)
+                }
+                self.components.append(component)
+            }
+        }
+        
+        if case let CBOR.byteString(sharedSequence)? = decodedCbor[0x04],
+           let decodedCbor = try? CBOR.decode(sharedSequence) {
+            self.sharedSequences = try? McuMgrSuitSharedSequence(cbor: decodedCbor)
+        }
+    }
+}
+
+// MARK: - McuMgrSuitSharedSequence
+
+class McuMgrSuitSharedSequence: CBORMappable {
+    
+    public var conditionVendorIdentifier: UInt64?
+    public var conditionClassIdentifier: UInt64?
+    
+    public required init(cbor: CBOR?) throws {
+        if case let CBOR.unsignedInt(vendorIdentifier)? = cbor?[1] {
+            self.conditionVendorIdentifier = vendorIdentifier
+        }
+        if case let CBOR.unsignedInt(classIdentifier)? = cbor?[2] {
+            self.conditionClassIdentifier = classIdentifier
+        }
+        try super.init(cbor: cbor)
+    }
+}


### PR DESCRIPTION
There's more functionality that needs to be built upon parsing the bootloader's name. This is just a start. And as for the McuMgrSuitManifest, we'd really like to implement a full parser, but this is as far as we got before we had to move on. So for now, it's not marked as Public.