### PR TITLE
Change: Don't set Bootloader to "mcuboot" if it's unknown

### DIFF
--- a/Source/McuMgrManifest.swift
+++ b/Source/McuMgrManifest.swift
@@ -122,7 +122,13 @@ extension McuMgrManifest {
             // Direct XIP, then the standard 'mcuBoot_version' will be there. But we can't discard
             // both being present. In which case, 'XIP' is more feature-complete.
             mcuBootVersion = _mcuBootXipVersion ?? version
-            bootloader = mcuBootVersion != nil ? .mcuboot : .suit
+            if content == .suitEnvelope {
+                bootloader = .suit
+            } else if mcuBootVersion != nil {
+                bootloader = .mcuboot
+            } else {
+                bootloader = .unknown
+            }
             // Load Address is an MCUBoot Manifest requirement.
             // For SUIT it's not set, so we set it to zero for backwards compatibility.
             loadAddress = bootloader == .mcuboot


### PR DESCRIPTION
Before, we set it to "suit" if we didn't know. Now, it's better to only decide if a "file" is a SUIT file if the content matches specifically the envelope. If there's an MCU Boot Version set, it's more likely it's an MCU Boot image, but if not, let's not make any assumptions.