### PR TITLE
Patch to Remove "Always Running Script" Xcode Issue

### DIFF
--- a/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		};
 		AA1FA7F62816B127004D8497 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
This is for the script that updates the Build Number. It's a Patch rather than a Fix, but whenever I've tried something else to go for this, then it didn't update when it was needed so, better just run it every time.