### PR TITLE
SuitFirmwareUpgradeDelegate + Resource API Introduction

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -340,6 +340,15 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
     }
 }
 
+// MARK: - Suit Upgrade Delegate
+
+extension FirmwareUpgradeViewController: SuitFirmwareUpgradeDelegate {
+    
+    func uploadRequestsResource(_ resource: FirmwareUpgradeManager.Resource) {
+        print("Work-in-Progress")
+    }
+}
+
 // MARK: - Document Picker
 
 extension FirmwareUpgradeViewController: UIDocumentMenuDelegate, UIDocumentPickerDelegate {

--- a/Source/Managers/DFU/SuitManifestManager.swift
+++ b/Source/Managers/DFU/SuitManifestManager.swift
@@ -39,6 +39,12 @@ public class SuitManifestManager {
         listManifests()
     }
     
+    public func provide(_ resource: FirmwareUpgradeManager.Resource) {
+        // TODO: Work In Progress.
+    }
+    
+    // MARK: Private
+    
     private func listManifests() {
         self.logDelegate?.log("Requesting List of Manifests...", ofCategory: .suit,
                               atLevel: .verbose)
@@ -57,7 +63,7 @@ public class SuitManifestManager {
         }
     }
     
-    // MARK: List Manifests Callback
+    // MARK: List Manifest Callback
     
     private lazy var listManifestCallback: McuMgrCallback<McuMgrManifestListResponse> = { [weak self] response, error in
         guard let self else { return }
@@ -77,6 +83,8 @@ public class SuitManifestManager {
         }
         self.validateNext()
     }
+    
+    // MARK: Role State Callback
     
     private lazy var roleStateCallback: McuMgrCallback<McuMgrManifestStateResponse> = { [weak self] response, error in
         guard let self else { return }

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -601,10 +601,6 @@ public final class McuMgrManifestStateResponse: McuMgrResponse {
 
 public final class McuMgrPollResponse: McuMgrResponse {
     
-    public enum Resource {
-        case file(named: String)
-    }
-    
     /**
      * Session identifier. Non-zero value, unique for image request.
      * Not provided if there is no pending image request.
@@ -623,7 +619,7 @@ public final class McuMgrPollResponse: McuMgrResponse {
      */
     public var isRequestingResource: Bool { sessionID != nil }
     
-    public var resource: Resource? {
+    public var resource: FirmwareUpgradeManager.Resource? {
         guard let resourceID else { return nil }
         let resourceString = String(cString: resourceID)
         if resourceString.hasPrefix("file://") {


### PR DESCRIPTION
We don't have an active use for these yet, we're working on the implementation side. But this was needed so that we could write the code that asks the API user for the resources requested by the Device's Firmware.