### PR TITLE
McuMgrPackage now parses a SUIT Manifest .ZIP

### DIFF
--- a/Source/McuMgrManifest.swift
+++ b/Source/McuMgrManifest.swift
@@ -12,6 +12,8 @@ import Foundation
 
 public struct McuMgrManifest: Codable {
     
+    // MARK: Public Properties
+    
     public let formatVersion: Int
     public let time: Int
     public let files: [File]
@@ -24,6 +26,8 @@ public struct McuMgrManifest: Codable {
     
     static let LoadAddressRegEx: NSRegularExpression! =
         try? NSRegularExpression(pattern: #"\"load_address\":0x[0-9a-z]+,"#, options: [.caseInsensitive])
+    
+    // MARK: Init
     
     public init(from url: URL) throws {
         guard let data = try? Data(contentsOf: url),
@@ -41,6 +45,12 @@ public struct McuMgrManifest: Codable {
         } catch {
             throw Error.unableToDecodeJSON
         }
+    }
+    
+    // MARK: API
+    
+    public func envelopeFile() -> File? {
+        files.first(where: { $0.content == .suitEnvelope })
     }
 }
 

--- a/Source/McuMgrSuitEnvelope.swift
+++ b/Source/McuMgrSuitEnvelope.swift
@@ -42,6 +42,12 @@ public struct McuMgrSuitEnvelope {
     
     // MARK: API
     
+    public func image() -> ImageManager.Image? {
+        // Currently only supported Hash Digest Algorithm is SHA256.
+        guard let hash = digest.hash(for: .sha256) else { return nil }
+        return ImageManager.Image(image: 0, hash: hash, data: data)
+    }
+    
     public func sizeString() -> String {
         return "\(data.count) bytes"
     }

--- a/Source/McuMgrSuitManifest.swift
+++ b/Source/McuMgrSuitManifest.swift
@@ -71,13 +71,9 @@ class McuMgrSuitCommonStructure: CBORMappable {
 
 class McuMgrSuitSharedSequence: CBORMappable {
     
-    public var conditionVendorIdentifier: UInt64?
     public var conditionClassIdentifier: UInt64?
     
     public required init(cbor: CBOR?) throws {
-        if case let CBOR.unsignedInt(vendorIdentifier)? = cbor?[1] {
-            self.conditionVendorIdentifier = vendorIdentifier
-        }
         if case let CBOR.unsignedInt(classIdentifier)? = cbor?[2] {
             self.conditionClassIdentifier = classIdentifier
         }


### PR DESCRIPTION
So, for SUIT Zip Packages, we do not care about the other files. We only look for the SUIT Envelope in the Manifest, and that file has a hash, or a digest we can sink our teeth onto, and then we can proceed with SUIT. But again, this is just one small step.