### PR TITLE
API Change: 'transporter' is now 'transport'

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -41,13 +41,13 @@ final class BaseViewController: UITabBarController {
         }
     }
     
-    var transporter: McuMgrTransport!
+    var transport: McuMgrTransport!
     var peripheral: DiscoveredPeripheral! {
         didSet {
-            let bleTransporter = McuMgrBleTransport(peripheral.basePeripheral)
-            bleTransporter.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
-            bleTransporter.delegate = self
-            transporter = bleTransporter
+            let bleTransport = McuMgrBleTransport(peripheral.basePeripheral)
+            bleTransport.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
+            bleTransport.delegate = self
+            transport = bleTransport
         }
     }
     
@@ -91,7 +91,7 @@ final class BaseViewController: UITabBarController {
     }
     
     override func viewWillDisappear(_ animated: Bool) {
-        transporter?.close()
+        transport?.close()
     }
 }
 
@@ -103,7 +103,7 @@ extension BaseViewController: PeripheralDelegate {
         self.state = state
         
         if state == .connected {
-            let defaultManager = DefaultManager(transporter: transporter)
+            let defaultManager = DefaultManager(transport: transport)
             defaultManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
             defaultManager.params { [weak self] response, error in
                 if let count = response?.bufferCount,

--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -54,8 +54,8 @@ class DeviceController: UITableViewController, UITextFieldDelegate {
         messageReceivedBackground.image = receivedBackground
         
         let baseController = parent as! BaseViewController
-        let transporter = baseController.transporter!
-        defaultManager = DefaultManager(transporter: transporter)
+        let transport: McuMgrTransport! = baseController.transport
+        defaultManager = DefaultManager(transport: transport)
         defaultManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
     }
     
@@ -104,7 +104,7 @@ class DeviceController: UITableViewController, UITextFieldDelegate {
                 } catch McuManagerError.mtuValueHasNotChanged {
                     // If MTU value did not change, try reassembly.
                     if let messageText = self?.messageSent.text,
-                       let bleTransport = self?.defaultManager.transporter as? McuMgrBleTransport,
+                       let bleTransport = self?.defaultManager.transport as? McuMgrBleTransport,
                        !bleTransport.chunkSendDataToMtuSize {
                         bleTransport.chunkSendDataToMtuSize = true
                         self?.send(message: messageText)

--- a/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
@@ -46,9 +46,9 @@ class FileDownloadViewController: UIViewController, McuMgrViewController {
         }
     }
     
-    var transporter: McuMgrTransport! {
+    var transport: McuMgrTransport! {
         didSet {
-            fsManager = FileSystemManager(transporter: transporter)
+            fsManager = FileSystemManager(transport: transport)
             fsManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }

--- a/Example/Example/View Controllers/Manager/FileUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileUploadViewController.swift
@@ -57,9 +57,9 @@ class FileUploadViewController: UIViewController, McuMgrViewController {
         fsManager.cancelTransfer()
     }
     
-    var transporter: McuMgrTransport! {
+    var transport: McuMgrTransport! {
         didSet {
-            fsManager = FileSystemManager(transporter: transporter)
+            fsManager = FileSystemManager(transport: transport)
             fsManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -35,10 +35,10 @@ class FilesController: UITableViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let baseController = parent as! BaseViewController
-        let transporter = baseController.transporter!
+        let transport = baseController.transport!
         
         var destination = segue.destination as? McuMgrViewController
-        destination?.transporter = transporter
+        destination?.transport = transport
     }
     
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -92,9 +92,9 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
     
     private var package: McuMgrPackage?
     private var dfuManager: FirmwareUpgradeManager!
-    var transporter: McuMgrTransport! {
+    var transport: McuMgrTransport! {
         didSet {
-            dfuManager = FirmwareUpgradeManager(transporter: transporter, delegate: self)
+            dfuManager = FirmwareUpgradeManager(transport: transport, delegate: self)
             dfuManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -132,9 +132,9 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
     private var package: McuMgrPackage?
     private var envelope: McuMgrSuitEnvelope?
     private var imageManager: ImageManager!
-    var transporter: McuMgrTransport! {
+    var transport: McuMgrTransport! {
         didSet {
-            imageManager = ImageManager(transporter: transporter)
+            imageManager = ImageManager(transport: transport)
             imageManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -30,10 +30,10 @@ class ImageController: UITableViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let baseController = parent as! BaseViewController
-        let transporter = baseController.transporter!
+        let transport: McuMgrTransport! = baseController.transport
         
         var destination = segue.destination as? McuMgrViewController
-        destination?.transporter = transporter
+        destination?.transport = transport
     }
     
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/Example/Example/View Controllers/Manager/LogsStatsController.swift
+++ b/Example/Example/View Controllers/Manager/LogsStatsController.swift
@@ -68,8 +68,8 @@ class LogsStatsController: UITableViewController {
     
     override func viewDidLoad() {
         let baseController = parent as! BaseViewController
-        let transporter = baseController.transporter!
-        statsManager = StatsManager(transporter: transporter)
+        let transport = baseController.transport!
+        statsManager = StatsManager(transport: transport)
         statsManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
     }
     

--- a/Example/Example/View Controllers/Manager/ResetViewController.swift
+++ b/Example/Example/View Controllers/Manager/ResetViewController.swift
@@ -19,9 +19,9 @@ class ResetViewController: UIViewController, McuMgrViewController {
     }
     
     private var defaultManager: DefaultManager!
-    var transporter: McuMgrTransport! {
+    var transport: McuMgrTransport! {
         didSet {
-            defaultManager = DefaultManager(transporter: transporter)
+            defaultManager = DefaultManager(transport: transport)
             defaultManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }

--- a/Example/Example/View Controllers/Manager/SettingsViewController.swift
+++ b/Example/Example/View Controllers/Manager/SettingsViewController.swift
@@ -20,9 +20,9 @@ class SettingsViewController: UIViewController, McuMgrViewController {
     }
     
     private var basicManager: BasicManager!
-    var transporter: McuMgrTransport! {
+    var transport: McuMgrTransport! {
         didSet {
-            basicManager = BasicManager(transporter: transporter)
+            basicManager = BasicManager(transport: transport)
             basicManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }

--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -57,11 +57,11 @@ class ImagesViewController: UIViewController , McuMgrViewController{
     private var lastResponse: McuMgrImageStateResponse?
     private var imageManager: ImageManager!
     private var defaultManager: DefaultManager!
-    var transporter: McuMgrTransport! {
+    var transport: McuMgrTransport! {
         didSet {
-            imageManager = ImageManager(transporter: transporter)
+            imageManager = ImageManager(transport: transport)
             imageManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
-            defaultManager = DefaultManager(transporter: transporter)
+            defaultManager = DefaultManager(transport: transport)
             defaultManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         }
     }

--- a/Example/Example/View Controllers/Manager/Widgets/McuMgrViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/McuMgrViewController.swift
@@ -9,5 +9,5 @@ import iOSMcuManagerLibrary
 
 protocol McuMgrViewController {
 
-    var transporter: McuMgrTransport! { get set }
+    var transport: McuMgrTransport! { get set }
 }

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A `FirmwareUpgradeManager` provides an easy way to perform firmware upgrades on 
 import iOSMcuManagerLibrary
 
 do {
-    // Initialize the BLE transporter using a scanned peripheral
+    // Initialize the BLE transport using a scanned peripheral
     let bleTransport = McuMgrBleTransport(cbPeripheral)
 
     // Initialize the FirmwareUpgradeManager using the transport and a delegate
@@ -224,7 +224,7 @@ Now, the issue is that there's a gap between the aforementioned API, and the out
 import iOSMcuManagerLibrary
 
 do {
-    // Initialize the BLE transporter using a scanned peripheral
+    // Initialize the BLE transport using a scanned peripheral
     let bleTransport = McuMgrBleTransport(cbPeripheral)
 
     // Initialize the FirmwareUpgradeManager using the transport and a delegate
@@ -252,7 +252,7 @@ SUIT, or [Software Update for the Internet of Things](https://datatracker.ietf.o
 import iOSMcuManagerLibrary
 
 do {
-    // Initialize the BLE transporter using a scanned peripheral
+    // Initialize the BLE transport using a scanned peripheral
     let bleTransport = McuMgrBleTransport(cbPeripheral)
 
     // Initialize the FirmwareUpgradeManager using the transport and a delegate
@@ -346,9 +346,9 @@ Setting `logDelegate` property in a manager gives access to low level logs, that
 ```swift
 import iOSMcuManagerLibrary
 
-// Initialize the BLE transporter using a scanned peripheral
+// Initialize the BLE transport using a scanned peripheral
 let bleTransport = McuMgrBleTransport(cbPeripheral)
-bleTransporter.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
+bleTransport.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
 
 // Initialize the DeviceManager using the transport and a delegate
 let deviceManager = DeviceManager(bleTransport, delegate)

--- a/Source/Managers/BasicManager.swift
+++ b/Source/Managers/BasicManager.swift
@@ -25,8 +25,8 @@ public class BasicManager: McuManager {
     
     // MARK: - Init
     
-    public init(transporter: McuMgrTransport) {
-        super.init(group: .basic, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: .basic, transport: transport)
     }
     
     // MARK: - Commands

--- a/Source/Managers/CrashManager.swift
+++ b/Source/Managers/CrashManager.swift
@@ -30,8 +30,8 @@ public class CrashManager: McuManager {
     // MARK: Initializers
     //**************************************************************************
 
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.crash, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.crash, transport: transport)
     }
 
     //**************************************************************************

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -66,12 +66,12 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     
     // MARK: Init
     
-    public init(transporter: McuMgrTransport, delegate: FirmwareUpgradeDelegate?) {
-        self.imageManager = ImageManager(transporter: transporter)
-        self.defaultManager = DefaultManager(transporter: transporter)
-        self.basicManager = BasicManager(transporter: transporter)
-        self.suitManager = SuitManager(transporter: transporter)
-        self.suitManifestManager = SuitManifestManager(transporter: transporter)
+    public init(transport: McuMgrTransport, delegate: FirmwareUpgradeDelegate?) {
+        self.imageManager = ImageManager(transport: transport)
+        self.defaultManager = DefaultManager(transport: transport)
+        self.basicManager = BasicManager(transport: transport)
+        self.suitManager = SuitManager(transport: transport)
+        self.suitManifestManager = SuitManifestManager(transport: transport)
         self.delegate = delegate
         self.state = .none
         self.paused = false
@@ -307,7 +307,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         objc_sync_setState(.reset)
         if !paused {
             log(msg: "Sending Reset command...", atLevel: .verbose)
-            defaultManager.transporter.addObserver(self)
+            defaultManager.transport.addObserver(self)
             defaultManager.reset(callback: resetCallback)
         }
     }
@@ -639,7 +639,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
                     log(msg: "Image \(image.image) (slot \(secondary.slot)) is already pending", atLevel: .warning)
                     log(msg: "Resetting the device...", atLevel: .verbose)
                     // reset() can't be called here, as it changes the state to RESET.
-                    defaultManager.transporter.addObserver(self)
+                    defaultManager.transport.addObserver(self)
                     defaultManager.reset(callback: self.resetCallback)
                     // The validate() method will be called again.
                     return
@@ -954,7 +954,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     
     /// Reconnect to the device and continue the
     private func reconnect() {
-        imageManager.transporter.connect { [weak self] result in
+        imageManager.transport.connect { [weak self] result in
             guard let self = self else {
                 return
             }

--- a/Source/Managers/DFU/SuitManifestManager.swift
+++ b/Source/Managers/DFU/SuitManifestManager.swift
@@ -22,8 +22,8 @@ public class SuitManifestManager {
     
     // MARK: Init
     
-    public init(transporter: McuMgrTransport) {
-        self.suitManager = SuitManager(transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        self.suitManager = SuitManager(transport: transport)
         self.roles = []
         self.responses = []
     }

--- a/Source/Managers/DefaultManager.swift
+++ b/Source/Managers/DefaultManager.swift
@@ -46,8 +46,8 @@ public class DefaultManager: McuManager {
     // MARK: Initializers
     //**************************************************************************
 
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.OS, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.OS, transport: transport)
     }
     
     // MARK: - Commands
@@ -63,8 +63,9 @@ public class DefaultManager: McuManager {
     public func echo(_ echo: String, callback: @escaping McuMgrCallback<McuMgrEchoResponse>) {
         let payload: [String:CBOR] = ["d": CBOR.utf8String(echo)]
         
-        let echoPacket = McuManager.buildPacket(scheme: transporter.getScheme(), version: .SMPv2,
-                                                op: .write, flags: 0, group: McuMgrGroup.OS.rawValue,
+        let echoPacket = McuManager.buildPacket(scheme: transport.getScheme(),
+                                                version: .SMPv2, op: .write,
+                                                flags: 0, group: McuMgrGroup.OS.rawValue,
                                                 sequenceNumber: 0, commandId: ID.echo, payload: payload)
         
         guard echoPacket.count <= BasicManager.MAX_ECHO_MESSAGE_SIZE_BYTES else {

--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -25,8 +25,8 @@ public class FileSystemManager: McuManager {
     
     // MARK: Init
     
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.filesystem, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.filesystem, transport: transport)
     }
     
     // MARK: Download
@@ -170,7 +170,7 @@ public class FileSystemManager: McuManager {
         // can't predict how many bytes the firmware will accept in each chunk.
         uploadConfiguration = configuration
         uploadConfiguration.reassemblyBufferSize = min(uploadConfiguration.reassemblyBufferSize, UInt64(UInt16.max))
-        if let bleTransport = transporter as? McuMgrBleTransport {
+        if let bleTransport = transport as? McuMgrBleTransport {
             bleTransport.numberOfParallelWrites = configuration.pipelineDepth
             bleTransport.chunkSendDataToMtuSize = configuration.reassemblyBufferSize != 0
         }
@@ -568,11 +568,12 @@ public class FileSystemManager: McuManager {
             payload.updateValue(CBOR.unsignedInt(UInt64(data.count)), forKey: "len")
         }
         // Build the packet and return the size.
-        let packet = McuManager.buildPacket(scheme: transporter.getScheme(), version: .SMPv2, op: .write,
-                                            flags: 0, group: group.rawValue, sequenceNumber: 0,
-                                            commandId: FilesystemID.file, payload: payload)
+        let packet = McuManager.buildPacket(scheme: transport.getScheme(), version: .SMPv2,
+                                            op: .write, flags: 0, group: group.rawValue,
+                                            sequenceNumber: 0, commandId: FilesystemID.file,
+                                            payload: payload)
         var packetOverhead = packet.count + 5
-        if transporter.getScheme().isCoap() {
+        if transport.getScheme().isCoap() {
             // Add 25 bytes to packet overhead estimate for the CoAP header.
             packetOverhead = packetOverhead + 25
         }

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -71,8 +71,8 @@ public class ImageManager: McuManager {
     // MARK: Initializers
     //**************************************************************************
 
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.image, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.image, transport: transport)
     }
     
     //**************************************************************************
@@ -208,7 +208,7 @@ public class ImageManager: McuManager {
         // Don't exceed UInt16.max payload size.
         uploadConfiguration.reassemblyBufferSize = min(uploadConfiguration.reassemblyBufferSize, UInt64(UInt16.max))
         
-        if let bleTransport = transporter as? McuMgrBleTransport {
+        if let bleTransport = transport as? McuMgrBleTransport {
             bleTransport.numberOfParallelWrites = configuration.pipelineDepth
             bleTransport.chunkSendDataToMtuSize = configuration.reassemblyBufferSize != 0
         }
@@ -572,11 +572,12 @@ public class ImageManager: McuManager {
             payload.updateValue(CBOR.byteString([UInt8](data.sha256())), forKey: "sha")
         }
         // Build the packet and return the size.
-        let packet = McuManager.buildPacket(scheme: transporter.getScheme(), version: .SMPv2, op: .write,
-                                            flags: 0, group: group.rawValue, sequenceNumber: 0,
-                                            commandId: ImageID.upload, payload: payload)
+        let packet = McuManager.buildPacket(scheme: transport.getScheme(), version: .SMPv2,
+                                            op: .write, flags: 0, group: group.rawValue,
+                                            sequenceNumber: 0, commandId: ImageID.upload,
+                                            payload: payload)
         var packetOverhead = packet.count + 5
-        if transporter.getScheme().isCoap() {
+        if transport.getScheme().isCoap() {
             // Add 25 bytes to packet overhead estimate for the CoAP header.
             packetOverhead = packetOverhead + 25
         }

--- a/Source/Managers/LogManager.swift
+++ b/Source/Managers/LogManager.swift
@@ -26,8 +26,8 @@ public class LogManager: McuManager {
     // MARK: Initializers
     //**************************************************************************
 
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.logs, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.logs, transport: transport)
     }
     
     //**************************************************************************

--- a/Source/Managers/RunTestManager.swift
+++ b/Source/Managers/RunTestManager.swift
@@ -21,8 +21,8 @@ public class RunTestManager: McuManager {
     // MARK: Initializers
     //**************************************************************************
 
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.run, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.run, transport: transport)
     }
     
     //**************************************************************************

--- a/Source/Managers/SettingsManager.swift
+++ b/Source/Managers/SettingsManager.swift
@@ -20,8 +20,8 @@ public class SettingsManager: McuManager {
     
     // MARK: Initializers
 
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.settings, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.settings, transport: transport)
     }
     
     // MARK: Commands

--- a/Source/Managers/ShellManager.swift
+++ b/Source/Managers/ShellManager.swift
@@ -27,8 +27,8 @@ public class ShellManager: McuManager {
     
     // MARK: Init
     
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.shell, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.shell, transport: transport)
     }
     
     // MARK: API

--- a/Source/Managers/StatsManager.swift
+++ b/Source/Managers/StatsManager.swift
@@ -25,8 +25,8 @@ public class StatsManager: McuManager {
     // MARK: Initializers
     //**************************************************************************
 
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.statistics, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.statistics, transport: transport)
     }
     
     //**************************************************************************

--- a/Source/Managers/SuitManager.swift
+++ b/Source/Managers/SuitManager.swift
@@ -61,8 +61,8 @@ public class SuitManager: McuManager {
     
     // MARK: Init
     
-    public init(transporter: McuMgrTransport) {
-        super.init(group: McuMgrGroup.suit, transporter: transporter)
+    public init(transport: McuMgrTransport) {
+        super.init(group: McuMgrGroup.suit, transport: transport)
     }
     
     // MARK: List
@@ -269,11 +269,12 @@ public class SuitManager: McuManager {
             payload.updateValue(CBOR.unsignedInt(UInt64(data.count)), forKey: "len")
         }
         // Build the packet and return the size.
-        let packet = McuManager.buildPacket(scheme: transporter.getScheme(), version: .SMPv2, op: .write,
-                                            flags: 0, group: group.rawValue, sequenceNumber: 0,
-                                            commandId: SuitID.envelopeUpload, payload: payload)
+        let packet = McuManager.buildPacket(scheme: transport.getScheme(), version: .SMPv2,
+                                            op: .write, flags: 0, group: group.rawValue,
+                                            sequenceNumber: 0, commandId: SuitID.envelopeUpload,
+                                            payload: payload)
         var packetOverhead = packet.count + 5
-        if transporter.getScheme().isCoap() {
+        if transport.getScheme().isCoap() {
             // Add 25 bytes to packet overhead estimate for the CoAP header.
             packetOverhead = packetOverhead + 25
         }

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -28,8 +28,7 @@ open class McuMgrResponse: CBORMappable {
     // MARK: Response Properties
     //**************************************************************************
 
-    /// The transport scheme used by the transporter. This is used to determine
-    /// how to parse the raw packet.
+    /// The transport's scheme. This is used to determine how to parse the raw packet.
     public var scheme: McuMgrScheme!
     
     /// The response's raw packet data. For CoAP transport schemes, this will
@@ -95,7 +94,7 @@ open class McuMgrResponse: CBORMappable {
     /// CBOR payload. An object of type <T> will be initialized which will map
     /// the CBOR payload values to the values in the object.
     ///
-    /// - parameter scheme: the transport scheme of the transporter.
+    /// - parameter scheme: the transport's scheme.
     /// - parameter data: The response's raw packet data.
     /// - parameter coapPayload: (Optional) payload for CoAP transport schemes.
     /// - parameter coapCode: (Optional) CoAP response code.
@@ -171,7 +170,7 @@ open class McuMgrResponse: CBORMappable {
     /// CBOR payload, An object of type <T> will be initialized which will map
     /// the CBOR payload values to the values in the object.
     ///
-    /// - parameter scheme: the transport scheme of the transporter.
+    /// - parameter scheme: the transport's scheme.
     /// - parameter data: The response's raw packet data.
     ///
     /// - returns: The McuMgrResponse on success or nil on failure.
@@ -187,7 +186,7 @@ open class McuMgrResponse: CBORMappable {
     /// CBOR payload, An object of type <T> will be initialized which will map
     /// the CBOR payload values to the values in the object.
     ///
-    /// - parameter scheme: The transport scheme of the transporter.
+    /// - parameter scheme: The transport's scheme.
     /// - parameter data: The response's raw packet data.
     /// - parameter coapPayload: The CoAP payload of the response.
     /// - parameter codeClass: The CoAP response code class.


### PR DESCRIPTION
This is a bad phrasing in our code / comments. At some point it needed to be changed.