### PR TITLE
Swift Version added as Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-![Platforms](https://img.shields.io/badge/platforms-iOS%20|%20macOS-333333.svg)
+![Swift](https://img.shields.io/badge/Swift-5.10-f05237.svg)
+![Platforms](https://img.shields.io/badge/Platforms-iOS%20|%20iPadOS%20|%20macOS-333333.svg)
 [![License](https://img.shields.io/github/license/NordicSemiconductor/IOS-nRF-Connect-Device-Manager)](https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/blob/master/LICENSE)
 [![Release](https://img.shields.io/github/release/NordicSemiconductor/IOS-nRF-Connect-Device-Manager.svg)](https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/releases)
-[![Swift Package Manager Compatible](https://img.shields.io/badge/SwiftPM-compatible-brightgreen)](https://swift.org/package-manager/)
+[![Swift Package Manager](https://img.shields.io/badge/SwiftPM-Compatible-brightgreen)](https://swift.org/package-manager/)
+[![CocoaPods](https://img.shields.io/badge/CocoaPods-Compatible-brightgreen)](https://cocoapods.org/)
 
 # nRF Connect Device Manager
 


### PR DESCRIPTION
I think, with the advent of Swift 6, a lot of people are going to be asking whether an API is "Swift 6 or not" so, it makes sense to have this listed at the top.