### PR TITLE
Fix: McuMgrPackage no longer considers itself the owner of your Caches Directory

### DIFF
--- a/Source/McuMgrPackage.swift
+++ b/Source/McuMgrPackage.swift
@@ -137,16 +137,15 @@ fileprivate extension McuMgrPackage {
         guard let cacheDirectoryPath = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first else {
             throw McuMgrPackage.Error.unableToAccessCacheDirectory
         }
-        let cacheDirectoryURL = URL(fileURLWithPath: cacheDirectoryPath, isDirectory: true)
+        
+        let unzipLocationPath = cacheDirectoryPath + "/" + UUID().uuidString + "/"
+        let unzipLocationURL = URL(filePath: unzipLocationPath, directoryHint: .isDirectory)
         
         let fileManager = FileManager()
-        let contentURLs = try fileManager.contentsOfDirectory(at: cacheDirectoryURL, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
-        contentURLs.forEach { url in
-            _ = try? fileManager.removeItem(at: url)
-        }
-        
-        try fileManager.unzipItem(at: url, to: cacheDirectoryURL)
-        let unzippedURLs = try fileManager.contentsOfDirectory(at: cacheDirectoryURL, includingPropertiesForKeys: nil, options: [])
+        try fileManager.createDirectory(atPath: unzipLocationPath,
+                                        withIntermediateDirectories: false)
+        try fileManager.unzipItem(at: url, to: unzipLocationURL)
+        let unzippedURLs = try fileManager.contentsOfDirectory(at: unzipLocationURL, includingPropertiesForKeys: nil, options: [])
         
         guard let dfuManifestURL = unzippedURLs.first(where: { $0.pathExtension == "json" }) else {
             throw McuMgrPackage.Error.manifestFileNotFound


### PR DESCRIPTION
This I think, is not an issue on iOS. But it is on macOS, where the Caches Directory returned by the API is not Application-specific, but shared. So if we clean it out and then unzip there, we're essentially deleting stuff we don't own. Also, like it happened in nRF Connect, we might be deleting the same file we want to DFU !