### PR TITLE
FirmwareUpgradeController API Expansion

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -328,14 +328,14 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
 
 extension FirmwareUpgradeViewController: SuitFirmwareUpgradeDelegate {
     
-    func uploadRequestsResource(_ resource: FirmwareUpgradeManager.Resource) {
+    func uploadRequestsResource(_ resource: FirmwareUpgradeResource) {
         guard let package else { return }
         guard let resourceImage = package.image(forResource: resource) else {
             upgradeDidFail(inState: .upload,
                            with: McuMgrPackage.Error.resourceNotFound(resource))
             return
         }
-        dfuManager.uploadResource(resource, image: resourceImage)
+        dfuManager.uploadResource(resource, data: resourceImage.data)
     }
 }
 

--- a/Source/Managers/DFU/FirmwareUpgradeController.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeController.swift
@@ -1,14 +1,16 @@
 //
 //  FirmwareUpgradeController.swift
-//  McuManager
+//  nRF Connect Device Manager
 //
 //  Created by Aleksander Nowakowski on 05/07/2018.
-//  Copyright © 2018 Runtime. All rights reserved.
+//  Copyright © 2024 Nordic Semiconductor ASA.
 //
 
 import Foundation
 
-public protocol FirmwareUpgradeController {
+// MARK: - FirmwareUpgradeController
+
+public protocol FirmwareUpgradeController: AnyObject {
     
     /// Pause the firmware upgrade.
     func pause()
@@ -24,4 +26,33 @@ public protocol FirmwareUpgradeController {
     
     /// Returns true if the upload is in progress.
     func isInProgress() -> Bool
+    
+    /**
+     Firmware upgrades on SUIT (Software Update for the Internet of Things) devices might request a ``FirmwareUpgradeResource`` to continue via callback. When that happens, this API allows you to provide said resource.
+     */
+    func uploadResource(_ resource: FirmwareUpgradeResource, data: Data) -> Void
+}
+
+// MARK: FirmwareUpgradeResource
+
+public enum FirmwareUpgradeResource: CustomStringConvertible {
+    case file(name: String)
+    
+    // MARK: Init
+    
+    public init?(_ resourceID: String) {
+        guard let filename = resourceID.components(separatedBy: "//").last else {
+            return nil
+        }
+        self = .file(name: String(filename))
+    }
+    
+    // MARK: CustomStringConvertible
+    
+    public var description: String {
+        switch self {
+        case .file(let name):
+            return "file://\(name)"
+        }
+    }
 }

--- a/Source/Managers/SuitManager.swift
+++ b/Source/Managers/SuitManager.swift
@@ -290,7 +290,7 @@ public class SuitManager: McuManager {
             }
             
             guard let resourceID = response.resourceID,
-                  let resource = FirmwareUpgradeManager.Resource(resourceID: resourceID),
+                  let resource = FirmwareUpgradeResource(resourceID),
                   let sessionID = response.sessionID else {
                 guard pollAttempts < Self.MAX_POLL_ATTEMPTS else {
                     // Assume success / device doesn't require anything.
@@ -395,7 +395,7 @@ enum SuitManagerState {
 // MARK: - SuitManagerError
 
 public enum SuitManagerError: Error, LocalizedError {
-    case suitDelegateRequiredForResource(_ resource: FirmwareUpgradeManager.Resource)
+    case suitDelegateRequiredForResource(_ resource: FirmwareUpgradeResource)
     
     public var errorDescription: String? {
         switch self {
@@ -412,5 +412,5 @@ public protocol SuitManagerDelegate: ImageUploadDelegate {
     /**
      In SUIT (Software Update for the Internet of Things), various resources, such as specific files, URL contents, etc. may be requested by the firmware device. When it does, this callback will be triggered.
      */
-    func uploadRequestsResource(_ resource: FirmwareUpgradeManager.Resource)
+    func uploadRequestsResource(_ resource: FirmwareUpgradeResource)
 }

--- a/Source/McuMgrPackage.swift
+++ b/Source/McuMgrPackage.swift
@@ -61,7 +61,7 @@ public struct McuMgrPackage {
         return name
     }
     
-    public func image(forResource resource: FirmwareUpgradeManager.Resource) -> ImageManager.Image? {
+    public func image(forResource resource: FirmwareUpgradeResource) -> ImageManager.Image? {
         switch resource {
         case .file(let name):
             return resources?.first(where: {
@@ -99,7 +99,7 @@ public extension McuMgrPackage {
     enum Error: Swift.Error, LocalizedError {
         case deniedAccessToScopedResource, notAValidDocument, unableToAccessCacheDirectory
         case manifestFileNotFound, manifestImageNotFound
-        case resourceNotFound(_ resource: FirmwareUpgradeManager.Resource)
+        case resourceNotFound(_ resource: FirmwareUpgradeResource)
         
         public var errorDescription: String? {
             switch self {

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -618,7 +618,7 @@ public final class McuMgrPollResponse: McuMgrResponse {
      */
     public var isRequestingResource: Bool { sessionID != nil }
     
-    public var resource: FirmwareUpgradeManager.Resource? {
+    public var resource: FirmwareUpgradeResource? {
         guard let resourceID else { return nil }
         if resourceID.hasPrefix("file://") {
             let filename = String(resourceID.suffix(from: "file://".endIndex))


### PR DESCRIPTION
So, if you're a user of the API, you need a way, when you get the SUIT Delegate Callback, to provide the Data. Most API users, we assume, will keep their reference to the Upgrade Manager of their own, as is the case of the Example App. But, if you don't and you might be using the Delegate's API's returned protocol FirmwareUpgradeController, you might need a way to provide your resource there. So if we expanded the Controller's API to support this. I also had the thought of killing this 'Controller' protocol since it's mostly the FirmwareUpgradeManager itself. But, I thought giving us more API flexibility in the future might be a good idea.