### PR TITLE
SuitListResponse

### DIFF
--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -596,6 +596,23 @@ public final class McuMgrManifestStateResponse: McuMgrResponse {
     }
 }
 
+// MARK: - SuitListResponse
+
+/**
+ This response type is not a part of the McuMgr/SUIT Protocol. We've added it to make the library API side match what most other APIs do, which is to return a ``McuMgrResponse`` for List in ``SuitManager``.
+ */
+public final class SuitListResponse: McuMgrResponse {
+    
+    public var states: [McuMgrManifestStateResponse]?
+    
+    public required init(cbor: CBOR?) throws {
+        try super.init(cbor: cbor)
+        if case let CBOR.array(states)? = cbor?["states"] {
+            self.states = try CBOR.toObjectArray(array: states) ?? []
+        }
+    }
+}
+
 // MARK: - McuMgrPollResponse
 
 public final class McuMgrPollResponse: McuMgrResponse {


### PR DESCRIPTION
For SuitManager's list, we now return a subtype of McuMgrResponse. This keeps the API in line with all the others. As for why this was not the case originally, it's because this API is not simple. We need to send one call, and build the response out of other responses. So there's no 'one McuMgrResponse' that we can return, so we build it instead. Hopefully we built it well.