### PR TITLE
fix(dfu): handle case where device is already in test mode 

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -1028,6 +1028,18 @@ extension FirmwareUpgradeManager: ImageUploadDelegate {
                 mark(firstUntestedImage, as: \.testSent)
                 return
             }
+            if configuration.upgradeMode == FirmwareUpgradeMode.testAndConfirm {
+                if let firstUnconfirmedImage = images.first(where: {
+                    $0.uploaded && $0.tested && !$0.confirmed && !$0.confirmSent }
+                ) {
+                    confirm(firstUnconfirmedImage)
+                    // We might send 'Confirm', but the firmware might not change the flag to reflect it.
+                    // If we don't track this internally, we could enter into an infinite loop always trying
+                    // to Confirm an image.
+                    mark(firstUnconfirmedImage, as: \.confirmSent)
+                    return
+                }
+            }
         case .uploadOnly:
             // Nothing to do in SUIT since does not support RESET Command and will
             // throw an Error if Reset is sent.


### PR DESCRIPTION
When attempting to test and confirm a device that had previously had test only run against it we encountered an issue where the library would not confirm the image and instead just reported success.

This patch handles the case when we are in test and confirm mode and there are no images to test but there are still images to confirm.