### PR TITLE
Updated Dependencies & Raised Minimum Deployment Version to iOS 12.0

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '12.0'
 use_frameworks!
 
 project 'nRF Connect Device Manager'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - iOSMcuManagerLibrary (1.7):
-    - SwiftCBOR (= 0.4.4)
-    - ZIPFoundation (= 0.9.11)
-  - SwiftCBOR (0.4.4)
-  - ZIPFoundation (0.9.11)
+    - SwiftCBOR (= 0.4.7)
+    - ZIPFoundation (= 0.9.19)
+  - SwiftCBOR (0.4.7)
+  - ZIPFoundation (0.9.19)
 
 DEPENDENCIES:
   - iOSMcuManagerLibrary (from `../`)
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSMcuManagerLibrary: ad3d47acf17b36954f1173ea5ead110921b84f76
-  SwiftCBOR: ce5354ec8b660da2d6fc754462881119dbe1f963
-  ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
+  iOSMcuManagerLibrary: e8ff62b609d6b4eaeb4c82960ab5cb332e03b8e4
+  SwiftCBOR: 465775bed0e8bac7bfb8160bcf7b95d7f75971e4
+  ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 3ed9fc6fb1d88f710c72ae76d9c383ed8480c8d2
+PODFILE CHECKSUM: f2511a9cba22bb3fd31be0da56fd26af29146341
 
 COCOAPODS: 1.15.2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SUIT and McuManager are related, but not interchangeable. SUIT relies on its own
 
 The library provides a transport agnostic implementation of the McuManager protocol. It contains a default implementation for BLE transport.
 
-> Minimum required iOS version is 9.0, originally released in Fall of 2015.
+> Minimum required iOS version is 12.0, originally released in Fall of 2018.
 
 > [!Warning]  
 > This library, the default & main API for Device Firmware Update by Nordic Semiconductor, **should not be confused with the previous protocol, NordicDFU**, serviced by the [Old DFU Library](https://github.com/NordicSemiconductor/IOS-DFU-Library).

--- a/iOSMcuManagerLibrary.podspec
+++ b/iOSMcuManagerLibrary.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager.git", :tag => "#{s.version}" }
   s.swift_versions = ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10"]
 
-  s.ios.deployment_target = "9.0"
+  s.ios.deployment_target = "12.0"
   s.osx.deployment_target = "10.13"
 
   s.source_files = "Source/**/*.{swift, h}"
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.dependency "SwiftCBOR", "0.4.4"
-  s.dependency "ZIPFoundation", "0.9.11"
+  s.dependency "SwiftCBOR", "0.4.7"
+  s.dependency "ZIPFoundation", "0.9.19"
 end


### PR DESCRIPTION
- SwiftCBOR now version 0.4.7
- ZIPFoundation now verison 0.9.19