### PR TITLE
API Change: McuMgrResponse's @rc property is now a McuMgrReturnCode enum

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -379,7 +379,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     private lazy var mcuManagerParametersCallback: McuMgrCallback<McuMgrParametersResponse> = { [weak self] response, error in
         guard let self = self else { return }
         
-        guard error == nil, let response, response.rc != 8 else {
+        guard error == nil, let response, response.rc != .unsupported else {
             self.log(msg: "Mcu Manager parameters not supported", atLevel: .warning)
             self.bootloaderInfo() // Continue to Bootloader Info.
             return
@@ -400,7 +400,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     private lazy var bootloaderInfoCallback: McuMgrCallback<BootloaderInfoResponse> = { [weak self] response, error in
         guard let self else { return }
         
-        guard error == nil, let response, response.rc != 8 else {
+        guard error == nil, let response, response.rc != .unsupported else {
             self.log(msg: "Bootloader Info not supported.", atLevel: .warning)
             self.log(msg: "Assuming MCUBoot Bootloader.", atLevel: .debug)
             self.bootloader = .mcuboot
@@ -427,7 +427,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     private lazy var bootloaderModeCallback: McuMgrCallback<BootloaderInfoResponse> = { [weak self] response, error in
         guard let self else { return }
         
-        guard error == nil, let response, response.rc != 8 else {
+        guard error == nil, let response, response.rc != .unsupported else {
             self.log(msg: "Bootloader Mode not supported", atLevel: .warning)
             self.validate() // Continue Upload
             return

--- a/Source/Managers/SuitManager.swift
+++ b/Source/Managers/SuitManager.swift
@@ -121,7 +121,7 @@ public class SuitManager: McuManager {
     private lazy var listManifestCallback: McuMgrCallback<McuMgrManifestListResponse> = { [weak self] response, error in
         guard let self else { return }
         
-        guard error == nil, let response, response.rc != 8 else {
+        guard error == nil, let response, response.rc != .unsupported else {
             self.logDelegate?.log("List Manifest Callback not Supported.", ofCategory: .suit, atLevel: .error)
             self.callback?(nil, error)
             return
@@ -141,7 +141,7 @@ public class SuitManager: McuManager {
     
     private lazy var roleStateCallback: McuMgrCallback<McuMgrManifestStateResponse> = { [weak self] response, error in
         guard let self else { return }
-        guard error == nil, let response, response.rc != 8 else {
+        guard error == nil, let response, response.rc != .unsupported else {
             self.logDelegate?.log("List Manifest Callback not Supported.", ofCategory: .suit, atLevel: .error)
             return
         }
@@ -297,7 +297,7 @@ public class SuitManager: McuManager {
         }
         
         if let response {
-            guard response.rc != 8 else {
+            guard response.rc != .unsupported else {
                 // Not supported, so either no polling or device restarted.
                 // It means success / continue.
                 self.uploadDelegate?.uploadDidFinish()


### PR DESCRIPTION
Previosuly, it was the raw unsigned integer value. This could backfire in ways I can't foresee, but the intention here is to make the value of the numbers more explicit, so we can write better code. (Please don't backfire too much.)