### PR TITLE
Crash Fix for nil McuMgr Parameters Response

### DIFF
--- a/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#\n# Set the build number to the current git commit count.\n# If we're using the Dev scheme, then we'll suffix the build\n# number with the current branch name, to make collisions\n# far less likely across feature branches.\n# Based on: http://w3facility.info/question/how-do-i-force-xcode-to-rebuild-the-info-plist-file-in-my-project-every-time-i-build-the-project/\n#\n# Updated with dSYM handling from http://yellowfeather.co.uk/blog/auto-incrementing-build-number-in-xcode-revisited/\n#\n# Seen here: http://blog.jaredsinclair.com/post/97193356620/the-best-of-all-possible-xcode-automated-build\n\ngit=`sh /etc/profile; which git`\nreferenceGitTag=\"1.7.1\"\nappBuild=`\"$git\" rev-list \"$referenceGitTag\"..HEAD --count`\nbranchName=`\"$git\" rev-parse --abbrev-ref HEAD`\necho \"buildNo $appBuild-$branchName\"\n\ndsym_plist=\"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist\"\ntarget_plist=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\n\nfor plist in \"$target_plist\" \"$dsym_plist\"; do\n    if [ -f \"$plist\" ]; then\n        /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $appBuild\" \"$plist\"\n        echo \"Build number set to $appBuild in ${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n    fi\n\ndone\n";
+			shellScript = "#\n# Set the build number to the current git commit count.\n# If we're using the Dev scheme, then we'll suffix the build\n# number with the current branch name, to make collisions\n# far less likely across feature branches.\n# Based on: http://w3facility.info/question/how-do-i-force-xcode-to-rebuild-the-info-plist-file-in-my-project-every-time-i-build-the-project/\n#\n# Updated with dSYM handling from http://yellowfeather.co.uk/blog/auto-incrementing-build-number-in-xcode-revisited/\n#\n# Seen here: http://blog.jaredsinclair.com/post/97193356620/the-best-of-all-possible-xcode-automated-build\n\ngit=`sh /etc/profile; which git`\nreferenceGitTag=\"1.7.2\"\nappBuild=`\"$git\" rev-list \"$referenceGitTag\"..HEAD --count`\nbranchName=`\"$git\" rev-parse --abbrev-ref HEAD`\necho \"buildNo $appBuild-$branchName\"\n\ndsym_plist=\"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist\"\ntarget_plist=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\n\nfor plist in \"$target_plist\" \"$dsym_plist\"; do\n    if [ -f \"$plist\" ]; then\n        /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $appBuild\" \"$plist\"\n        echo \"Build number set to $appBuild in ${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n    fi\n\ndone\n";
 		};
 		E0CEE0D742922CA92222028F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -533,7 +533,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nordicsemi.nrfconnect.devicemanager;
 				PRODUCT_NAME = "Device Manager";
 				SWIFT_VERSION = 5.0;
@@ -557,7 +557,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nordicsemi.nrfconnect.devicemanager;
 				PRODUCT_NAME = "Device Manager";
 				SWIFT_VERSION = 5.0;

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -385,13 +385,19 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
             return
         }
         
-        self.log(msg: "Mcu Manager parameters received (\(response.bufferCount) x \(response.bufferSize))", atLevel: .application)
-        if response.bufferSize > UInt16.max {
-            response.bufferSize = UInt64(UInt16.max)
+        guard let bufferCount = response.bufferCount, var bufferSize = response.bufferSize else {
+            self.log(msg: "Mcu Manager parameters did not return an error, but neither did it provide valide bufferCount nor bufferSize values.", atLevel: .warning)
+            self.bootloaderInfo() // Continue to Bootloader Info.
+            return
+        }
+        
+        self.log(msg: "Mcu Manager parameters received (\(bufferCount) x \(bufferSize))", atLevel: .application)
+        if bufferSize > UInt16.max {
+            bufferSize = UInt64(UInt16.max)
             self.log(msg: "Parameters SAR Buffer Size is larger than maximum of \(UInt16.max) bytes. Reducing Buffer Size to maximum value.", atLevel: .warning)
         }
-        self.log(msg: "Setting SAR Buffer Size to \(response.bufferSize) bytes.", atLevel: .verbose)
-        self.configuration.reassemblyBufferSize = response.bufferSize
+        self.log(msg: "Setting SAR Buffer Size to \(bufferSize) bytes.", atLevel: .verbose)
+        self.configuration.reassemblyBufferSize = bufferSize
         self.bootloaderInfo() // Continue to Bootloader Mode.
     }
     

--- a/iOSMcuManagerLibrary.podspec
+++ b/iOSMcuManagerLibrary.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "iOSMcuManagerLibrary"
-  s.version = "1.7.1"
+  s.version = "1.7.3"
   s.license = { :type => "Apache 2.0", :file => "LICENSE" }
   s.summary = "A mobile management library for devices running Apache Mynewt, Zephyr (McuMgr) and SUIT (Software Update for the Internet of Things)."
   s.homepage = "https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager"


### PR DESCRIPTION
So, we might not get an error. We might not get an invalid / unsupported code, and yet, no values for bufferSize and bufferCount are returned, hence the crash. Better to adopt some defensive programming.