### PR TITLE
Optimization: Reduced Memory Pressure by autoreleasing generated Strings in hexEncodedString()

### DIFF
--- a/Source/Extensions/Data+McuManager.swift
+++ b/Source/Extensions/Data+McuManager.swift
@@ -57,17 +57,20 @@ public extension Data {
             format.append(" ")
         }
         
-        var bytes = self
-        if options.contains(.reverseEndianness) {
-            bytes.reverse()
-        }
-        
-        var body = bytes.map {
-            String(format: format, $0)
-        }.joined()
-        
-        if options.contains(.twoByteSpacing) {
-            body = body.inserting(separator: " ", every: 4)
+        var body: String = ""
+        autoreleasepool {
+            var bytes = self
+            if options.contains(.reverseEndianness) {
+                bytes.reverse()
+            }
+            
+            body = bytes.map {
+                String(format: format, $0)
+            }.joined()
+            
+            if options.contains(.twoByteSpacing) {
+                body = body.inserting(separator: " ", every: 4)
+            }
         }
         
         let prefix = options.contains(.prepend0x) ? "0x" : ""


### PR DESCRIPTION
We flagged the _send() function in McuMgrBleTransport as being responsible for increase in memory pressure when performing DFU. And the culprit, was appending Strings. We don't do enough complicated Strings in the _send() function itself, except, that we log all the bytes that we send. And we send a lot of bytes in a very small amount of time, so this optimization makes sense here.