### PR TITLE
Change: Retrieve Connected Peripherals advertising SMP Service on Scan Start

### DIFF
--- a/Example/Example/View Controllers/Scanner/ScannerViewController.swift
+++ b/Example/Example/View Controllers/Scanner/ScannerViewController.swift
@@ -46,6 +46,11 @@ class ScannerViewController: UITableViewController, CBCentralManagerDelegate, UI
         
         if centralManager.state == .poweredOn {
             activityIndicator.startAnimating()
+            
+            let connectedPeripherals = centralManager.retrieveConnectedPeripherals(withServices: [McuMgrBleTransportConstant.SMP_SERVICE])
+            for peripheral in connectedPeripherals {
+                centralManager(centralManager, didDiscover: peripheral, advertisementData: [:], rssi: -127)
+            }
             centralManager.scanForPeripherals(withServices: nil, options: [CBCentralManagerScanOptionAllowDuplicatesKey : true])
         }
     }


### PR DESCRIPTION
This is an attempt to allow users to update already-connected devices. Primarily HID devices such as Keyboards and Mice.