### PR TITLE
Initial Implementation of 'LIST' Command for SUIT Bootloader

### DIFF
--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -17,9 +17,31 @@ class ImagesViewController: UIViewController , McuMgrViewController{
     
     @IBAction func read(_ sender: UIButton) {
         busy()
-        imageManager.list { [weak self] response, error in
-            self?.lastResponse = response
-            self?.handle(response, error)
+        guard let bootloader else {
+            defaultManager.bootloaderInfo(query: .name) { [weak self] response, error in
+                guard let self else { return }
+                guard error == nil, let response else {
+                    self.bootloader = .mcuboot
+                    return
+                }
+                self.bootloader = response.bootloader
+                read(sender)
+            }
+            return
+        }
+        
+        switch bootloader {
+        case .suit:
+            suitManager.listManifest { [weak self] response, error in
+                self?.suitListResponse = response
+                self?.handle(suitListResponse: response, error)
+            }
+            break
+        case .mcuboot, .unknown:
+            imageManager.list { [weak self] response, error in
+                self?.lastResponse = response
+                self?.handle(response, error)
+            }
         }
     }
     
@@ -54,11 +76,19 @@ class ImagesViewController: UIViewController , McuMgrViewController{
         }
     }
     
-    private var lastResponse: McuMgrImageStateResponse?
-    private var imageManager: ImageManager!
     private var defaultManager: DefaultManager!
+    private var bootloader: BootloaderInfoResponse.Bootloader?
+    
+    private var suitManager: SuitManager!
+    private var suitListResponse: SuitListResponse?
+    
+    private var imageManager: ImageManager!
+    private var lastResponse: McuMgrImageStateResponse?
+    
     var transport: McuMgrTransport! {
         didSet {
+            suitManager = SuitManager(transport: transport)
+            suitManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
             imageManager = ImageManager(transport: transport)
             imageManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
             defaultManager = DefaultManager(transport: transport)
@@ -98,6 +128,32 @@ class ImagesViewController: UIViewController , McuMgrViewController{
         view.translatesAutoresizingMaskIntoConstraints = false
     }
     
+    // MARK: handle(suitListResponse:error:)
+    
+    private func handle(suitListResponse response: SuitListResponse?, _ error: Error?) {
+        if let response {
+            switch response.result {
+            case .success:
+                testAction.isEnabled = false
+                confirmAction.isEnabled = true
+                eraseAction.isEnabled = true
+                updateUI(text: getInfo(from: response), color: .primary, readEnabled: true)
+            case .failure(let error):
+                updateUI(text: error.localizedDescription,
+                         color: .systemRed, readEnabled: true)
+            }
+        } else {
+            readAction.isEnabled = true
+            message.textColor = .systemRed
+            if let error {
+                message.text = error.localizedDescription
+            } else {
+                message.text = "Empty Response"
+            }
+        }
+        (parent as! ImageController).innerViewReloaded()
+    }
+    
     // MARK: handle(response:error:)
     
     private func handle(_ response: McuMgrImageStateResponse?, _ error: Error?) {
@@ -128,6 +184,21 @@ class ImagesViewController: UIViewController , McuMgrViewController{
     }
     
     // MARK: getInfo()
+    
+    private func getInfo(from response: SuitListResponse) -> String {
+        let roles = response.roles ?? []
+        let states = response.states ?? []
+        assert(roles.count == states.count)
+        
+        var info = ""
+        for (role, state) in zip(roles, states) {
+            let classString = (try? state.classUUID()?.uuidString) ?? "N/A"
+            let vendorString = (try? state.vendorUUID()?.uuidString) ?? "N/A"
+            let digestString = Data(state.digest ?? []).hexEncodedString(options: [.prepend0x, .upperCase])
+            info += "• Role: \(role.description)\n  Sequence Number: \(state.sequenceNumberHexString() ?? "N/A")\n  Class: \(classString)\n  Vendor: \(vendorString)\n  Downgrade Policy: \(state.downgradePreventionPolicy?.description ?? "N/A")\n  Independent Update Policy: \(state.independentUpdateabilityPolicy?.description ?? "N/A")\n  Signature Verification: \(state.signatureCheck?.description ?? "N/A")\n  Verification Policy: \(state.signatureVerificationPolicy?.description ?? "N/A")\n  Digest: \(digestString)\n  Digest Algorithm: \(state.digestAlgorithm?.description ?? "N/A")\n  Version: \(state.semanticVersionString() ?? "N/A")\n\n"
+        }
+        return info
+    }
     
     private func getInfo(from response: McuMgrImageStateResponse) -> String {
         let images = response.images ?? []


### PR DESCRIPTION
Instead of showing the result of the pre-existing ImageManager's 'LIST' Command, we now parse the SUIT roles and state.