### PR TITLE
Added Detection of SUIT Cache Files in McuMgrManifest

### DIFF
--- a/Source/McuMgrManifest.swift
+++ b/Source/McuMgrManifest.swift
@@ -167,6 +167,7 @@ public extension McuMgrManifest.File {
     
     enum ContentType: String, RawRepresentable, Codable, CustomStringConvertible {
         case unknown
+        case suitCache = "cache"
         case suitEnvelope = "suit-envelope"
         case bin
         case application
@@ -175,6 +176,8 @@ public extension McuMgrManifest.File {
             switch self {
             case .unknown:
                 return "Unknown"
+            case .suitCache:
+                return "SUIT Cache"
             case .suitEnvelope:
                 return "SUIT Envelope"
             case .bin:


### PR DESCRIPTION
We can't change the behaviour of DFU if we can't detect there's a cache file as part of the envelope.