### PR TITLE
Added Support for Uploading SUIT Partition(s)

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -98,7 +98,6 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
         present(alertViewController, animated: true)
     }
     
-    static let uploadImages = [0, 1, 2, 3]
     @IBAction func start(_ sender: UIButton) {
         if let envelope = package?.envelope {
             // SUIT has "no mode" to select

--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -148,7 +148,7 @@ class ImagesViewController: UIViewController , McuMgrViewController{
             return
         }
         
-        let alertController = UIAlertController(title: "Select image", message: nil, preferredStyle: .actionSheet)
+        let alertController = UIAlertController(title: "Select Image", message: nil, preferredStyle: .actionSheet)
         for image in responseImages {
             guard !image.confirmed else { continue }
             let title = "Image \(image.image), slot \(image.slot)"

--- a/Source/McuMgrPackage.swift
+++ b/Source/McuMgrPackage.swift
@@ -22,7 +22,16 @@ public struct McuMgrPackage {
     public init(from url: URL) throws {
         switch UTI.forFile(url) {
         case .bin:
-            self.images = try [ImageManager.Image(fromBinFile: url)]
+            let binImage = try ImageManager.Image(fromBinFile: url, forTarget: 0)
+            if binImage.hash.isEmpty {
+                // Only SUIT binaries have no hash.
+                let partitions = 0...3
+                self.images = try partitions.map {
+                    try ImageManager.Image(fromBinFile: url, forTarget: $0)
+                }
+            } else {
+                self.images = [binImage]
+            }
             self.envelope = nil
             self.resources = nil
         case .zip:
@@ -47,16 +56,20 @@ public struct McuMgrPackage {
     
     public func imageName(at index: Int) -> String {
         guard let name = images[index].name else {
-            let coreName: String
-            switch images[index].image {
-            case 0:
-                coreName = "App Core"
-            case 1:
-                coreName = "Net Core"
-            default:
-                coreName = "Image \(index)"
+            if images[index].hash.isEmpty {
+                return "Partition \(index)"
+            } else {
+                let coreName: String
+                switch images[index].image {
+                case 0:
+                    coreName = "App Core"
+                case 1:
+                    coreName = "Net Core"
+                default:
+                    coreName = "Image \(index)"
+                }
+                return "\(coreName) Slot \(images[index].slot)"
             }
-            return "\(coreName) Slot \(images[index].slot)"
         }
         return name
     }
@@ -83,8 +96,13 @@ public struct McuMgrPackage {
     public func hashString() -> String {
         var result = ""
         for (i, image) in images.enumerated() {
-            let hashString = image.hash.hexEncodedString(options: .upperCase)
-            result += "0x\(hashString.prefix(6))...\(hashString.suffix(6)) (\(imageName(at: i)))"
+            // SUIT binaries have no hash.
+            if image.hash.isEmpty {
+                result += "No Hash found"
+            } else {
+                let hashString = image.hash.hexEncodedString(options: .upperCase)
+                result += "0x\(hashString.prefix(6))...\(hashString.suffix(6)) (\(imageName(at: i)))"
+            }
             guard i != images.count - 1 else { continue }
             result += "\n"
         }
@@ -208,9 +226,13 @@ fileprivate extension McuMgrPackage {
 
 fileprivate extension ImageManager.Image {
     
-    init(fromBinFile url: URL) throws {
+    /**
+     - Note: Due to SUIT, all files are no longer guaranteed to be able to have a hash. So,
+     we must now accept `Image`(s) with no proper hash.
+     */
+    init(fromBinFile url: URL, forTarget targetImage: Int) throws {
         let binData = try Data(contentsOf: url)
-        let binHash = try McuMgrImage(data: binData).hash
-        self.init(image: 0, hash: binHash, data: binData)
+        let binHash = try? McuMgrImage(data: binData).hash
+        self.init(image: targetImage, content: .bin, hash: binHash ?? Data(), data: binData)
     }
 }


### PR DESCRIPTION
.bin files are common for regular McuMgr Updates targeting "App Core" or Image 0. However, .bin files may also contain SUIT Data for specific partitions, which the user might want to send. So we've opened up the Hash restriction, and try to detect whether a .bin file is destined for SUIT or McuBoot, and allow you to select which Partition you'd like to target, instead of a specific Image or Core.