### PR TITLE
Fix: Length of Advanced Commands Text is now refreshed on Update

### DIFF
--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -7,7 +7,7 @@
 import UIKit
 import iOSMcuManagerLibrary
 
-class ImagesViewController: UIViewController , McuMgrViewController{
+class ImagesViewController: UIViewController, McuMgrViewController {
     
     @IBOutlet weak var message: UILabel!
     @IBOutlet weak var readAction: UIButton!
@@ -281,6 +281,7 @@ class ImagesViewController: UIViewController , McuMgrViewController{
         message.text = text
         message.textColor = color
         readAction.isEnabled = readEnabled
+        (parent as! ImageController).innerViewReloaded()
     }
     
     private func busy() {


### PR DESCRIPTION
Before this change, the cell containing the text of the 'Read' / 'List' Command for example would grow in size, but never update when the displayed text shrank, so you could end up with blank space everywhere except in the middle of the screen. This is a brute force approach, but oh well.