### PR TITLE
Fix to allow Partition Selection in Advanced Mode only for SUIT

### DIFF
--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -15,6 +15,8 @@ class ImagesViewController: UIViewController, McuMgrViewController {
     @IBOutlet weak var confirmAction: UIButton!
     @IBOutlet weak var eraseAction: UIButton!
     
+    // MARK: read(sender:)
+    
     @IBAction func read(_ sender: UIButton) {
         busy()
         requestBootloaderIfNecessary(sender: sender) { [weak self] sender, bootloader in
@@ -33,6 +35,8 @@ class ImagesViewController: UIViewController, McuMgrViewController {
         }
     }
     
+    // MARK: test(sender:)
+    
     @IBAction func test(_ sender: UIButton) {
         selectImageCore() { [weak self] imageHash in
             self?.busy()
@@ -42,6 +46,8 @@ class ImagesViewController: UIViewController, McuMgrViewController {
             }
         }
     }
+    
+    // MARK: confirm(sender:)
     
     @IBAction func confirm(_ sender: UIButton) {
         requestBootloaderIfNecessary(sender: sender) { [weak self] sender, bootloader in
@@ -72,6 +78,8 @@ class ImagesViewController: UIViewController, McuMgrViewController {
         }
     }
     
+    // MARK: erase(sender:)
+    
     @IBAction func erase(_ sender: UIButton) {
         busy()
         requestBootloaderIfNecessary(sender: sender) { [weak self] sender, bootloader in
@@ -99,6 +107,8 @@ class ImagesViewController: UIViewController, McuMgrViewController {
             }
         }
     }
+    
+    // MARK: Properties
     
     private var defaultManager: DefaultManager!
     private var bootloader: BootloaderInfoResponse.Bootloader?
@@ -148,7 +158,7 @@ class ImagesViewController: UIViewController, McuMgrViewController {
             return
         }
         
-        let alertController = UIAlertController(title: "Select Image", message: nil, preferredStyle: .actionSheet)
+        let alertController = buildSelectImageController()
         for image in responseImages {
             guard !image.confirmed else { continue }
             let title = "Image \(image.image), slot \(image.slot)"
@@ -156,16 +166,11 @@ class ImagesViewController: UIViewController, McuMgrViewController {
                 callback(image.hash)
             })
         }
-        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel))
     
-        // If the device is an iPad set the popover presentation controller
-        if let presenter = alertController.popoverPresentationController {
-            presenter.sourceView = self.view
-            presenter.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
-            presenter.permittedArrowDirections = []
-        }
         present(alertController, animated: true)
     }
+    
+    // MARK: viewDidLoad()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -277,12 +282,16 @@ class ImagesViewController: UIViewController, McuMgrViewController {
         return info
     }
     
+    // MARK: updateUI(text:color:readEnabled)
+    
     private func updateUI(text: String, color: UIColor, readEnabled: Bool) {
         message.text = text
         message.textColor = color
         readAction.isEnabled = readEnabled
         (parent as! ImageController).innerViewReloaded()
     }
+    
+    // MARK: busy()
     
     private func busy() {
         readAction.isEnabled = false

--- a/Example/Example/View Controllers/Manager/Widgets/McuMgrViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/McuMgrViewController.swift
@@ -10,4 +10,25 @@ import iOSMcuManagerLibrary
 protocol McuMgrViewController {
 
     var transport: McuMgrTransport! { get set }
+    
+    func buildSelectImageController() -> UIAlertController
+}
+
+extension McuMgrViewController where Self: UIViewController {
+    
+    // MARK: buildSelectImageController()
+    
+    func buildSelectImageController() -> UIAlertController {
+        let alertController = UIAlertController(title: "Select", message: nil, preferredStyle: .actionSheet)
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+    
+        // If the device is an iPad set the popover presentation controller
+        if let presenter = alertController.popoverPresentationController {
+            presenter.sourceView = self.view
+            presenter.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            presenter.permittedArrowDirections = []
+        }
+        
+        return alertController
+    }
 }

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -56,6 +56,34 @@ public class ImageManager: McuManager {
             self.hash = image.hash
             self.data = image.data
         }
+        
+        // MARK: imageName()
+        
+        public func imageName() -> String {
+            if let name {
+                return name
+            }
+            
+            guard !hash.isEmpty else {
+                return "Partition \(image)"
+            }
+            
+            switch content {
+            case .suitEnvelope:
+                return "SUIT Envelope"
+            default:
+                let coreName: String
+                switch image {
+                case 0:
+                    coreName = "App Core"
+                case 1:
+                    coreName = "Net Core"
+                default:
+                    coreName = "Image \(image)"
+                }
+                return "\(coreName) Slot \(slot)"
+            }
+        }
     }
     
     override class var TAG: McuMgrLogCategory { .image }


### PR DESCRIPTION
We need to allow, in 'Advanced' Mode, for the user to select multiple .bin files and do the update themselves. This means, we want to allow the user to select to which Partition they'd like to send the .bin file. We hacked this earlier, making a single .bin destined for SUIT to show up as multiple 'Image's. Which is... a hack. So we decided to put the hacky code somewhere else that makes more sense, which is in the UI. This has led to other API changes, primarily the code to get the 'name' of an Image.