### PR TITLE
Improved Readability of TabBar in iOS 15 or higher

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -88,6 +88,19 @@ final class BaseViewController: UITabBarController {
     
     override func viewDidLoad() {
         title = peripheral.advertisedName
+        
+        if #available(iOS 15.0, *) {
+            let appearance = UITabBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = UIColor.dynamicColor(light: .systemBackground, dark: .secondarySystemBackground)
+           
+            tabBar.tintColor = .accent
+            tabBar.standardAppearance = appearance
+            tabBar.scrollEdgeAppearance = appearance
+        } else {
+            tabBar.tintColor = .accent
+            tabBar.isTranslucent = false
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
We can't properly test for devices older than 15, but we think majority of use cases, or users, will fall within this category. In any case, we've made the UITabBar more readable in both Light and Dark modes. Crazy to think Dark Mode was introduced back in 2019...