### PR TITLE
"Barcode" Issue Improvement

### DIFF
--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -51,7 +51,9 @@ class ImageController: UITableViewController {
     
     @objc func modeSwitched() {
         showModeSwitch(toggle: true)
-        tableView.reloadData()
+        DispatchQueue.main.async { [unowned self] in
+            self.tableView.reloadData()
+        }
     }
     
     private func showModeSwitch(toggle: Bool = false) {


### PR DESCRIPTION
In Advanced Mode, with a File Selected and if we perform a Read / List command and the output is fairly long, when switching between tabs the UI might look like a stretched barcode at times. This is due to the blunt instrument that is 'reloadData' applied on the UITableView. This is a fractional improvement.