### PR TITLE
Fix: Don't send Erase App Settings to SUIT Bootloader

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -70,6 +70,8 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         
         var suitConfiguration = configuration
         suitConfiguration.upgradeMode = .uploadOnly
+        // Erase App Settings is not supported by SUIT Bootloader.
+        suitConfiguration.eraseAppSettings = false
         try start(images: package.images, using: suitConfiguration)
     }
     


### PR DESCRIPTION
By default, Erase App Settings is enabled due to it being preferred for McuBoot updates. But SUIT can return an error which could result in the user getting an Error code when the SUIT update was successful.