### PR TITLE
Fix: FileSystemManager's closeAll() op should be 'write' instead of 'read'

### DIFF
--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -244,7 +244,7 @@ public class FileSystemManager: McuManager {
     ///
     /// - parameter callback: The callback.
     public func closeAll(name: String, callback: @escaping McuMgrCallback<McuMgrResponse>) {
-        send(op: .read, commandId: FilesystemID.closeFile, payload: nil, callback: callback)
+        send(op: .write, commandId: FilesystemID.closeFile, payload: nil, callback: callback)
     }
     
     // MARK: State


### PR DESCRIPTION
Raised via GitHub Issue here: https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/297