### PR TITLE
Added "mcuboot" ContentType

### DIFF
--- a/Source/McuMgrManifest.swift
+++ b/Source/McuMgrManifest.swift
@@ -178,6 +178,7 @@ public extension McuMgrManifest.File {
         case suitEnvelope = "suit-envelope"
         case bin
         case application
+        case mcuboot
         
         public var description: String {
             switch self {
@@ -191,6 +192,8 @@ public extension McuMgrManifest.File {
                 return "Binary"
             case .application:
                 return "Application"
+            case .mcuboot:
+                return "MCUboot (Bootloader)"
             }
         }
     }


### PR DESCRIPTION
We're just adding the enum value here, not implementing the bootloader update (yet). Also, do not confuse the "content" to be an mcuboot [bootloader] with the bootloader being mcuboot. Though presumably they should be, if the content is an mcuboot bootloader.