### PR TITLE
Correct Settings write value CBOR type

### DIFF
--- a/Source/Managers/SettingsManager.swift
+++ b/Source/Managers/SettingsManager.swift
@@ -40,9 +40,9 @@ public class SettingsManager: McuManager {
     /// - parameter name: The name of the sys config variable to write.
     /// - parameter value: The value of the sys config variable to write.
     /// - parameter callback: The response callback.
-    public func write(name: String, value: String, callback: @escaping McuMgrCallback<McuMgrResponse>) {
+    public func write(name: String, value: [UInt8], callback: @escaping McuMgrCallback<McuMgrResponse>) {
         let payload: [String:CBOR] = ["name": CBOR.utf8String(name),
-                                      "val":  CBOR.utf8String(value)]
+                                      "val":  CBOR.byteString(value)]
         send(op: .write, commandId: ConfigID.zero, payload: payload, callback: callback)
     }
 }


### PR DESCRIPTION
From https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_3.html#write-setting-request, settings write should be a bstr.

This would match the behaviour for Android
(https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/blob/94becd03c88a7acfc164db2cea5fe80bdd3106e4/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/SettingsManager.java#L175-L181)