### PR TITLE
Deleted unnecessary #available(s)

### DIFF
--- a/Example/Example/View Controllers/Intro/IntroViewController.swift
+++ b/Example/Example/View Controllers/Intro/IntroViewController.swift
@@ -64,11 +64,7 @@ private extension IntroViewController {
             return
         }
         
-        if #available(iOS 10.0, *) {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-        } else {
-            UIApplication.shared.openURL(url)
-        }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
 }
 

--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -414,7 +414,7 @@ extension McuMgrBleTransport: McuMgrTransport {
         writeState.sharedLock {
             var writesSent = 0
             for chunk in data {
-                if writesSent > McuMgrBleTransportConstant.WRITE_VALUE_BUFFER_SIZE, #available(iOS 11.0, *) {
+                if writesSent > McuMgrBleTransportConstant.WRITE_VALUE_BUFFER_SIZE {
                     var waitAttempts = 0
                     while !peripheral.canSendWriteWithoutResponse {
                         usleep(McuMgrBleTransportConstant.CONNECTION_BUFFER_WAIT_TIME_USECONDS)

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -113,11 +113,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         
         log(msg: "Upgrade started with \(images.count) image(s) using '\(configuration.upgradeMode)' mode",
             atLevel: .application)
-        if #available(iOS 10.0, watchOS 3.0, *) {
-            dispatchPrecondition(condition: .onQueue(.main))
-        } else {
-            assert(Thread.isMainThread)
-        }
+        dispatchPrecondition(condition: .onQueue(.main))
         delegate?.upgradeDidStart(controller: self)
         
         requestMcuMgrParameters()

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -411,10 +411,7 @@ public class ImageManager: McuManager {
         [weak self] (response: McuMgrUploadResponse?, error: Error?) in
         // Ensure the manager is not released.
         guard let self else { return }
-        
-        if #available(iOS 10.0, watchOS 3.0, *) {
-            dispatchPrecondition(condition: .onQueue(.main))
-        }
+        dispatchPrecondition(condition: .onQueue(.main))
         
         // Check for an error.
         if let error {


### PR DESCRIPTION
The minimum version was raised to iOS 12 and equivalent, so these are not needed anymore. We kept one, as a reference for MTU size(s) of past versions.