### PR TITLE
Bumped Write Buffer Size Constant from '10' to '16'

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -457,7 +457,7 @@ public enum McuMgrBleTransportConstant {
     /**
      How many `cbPeripheral.writeValue()` calls can be enqueued before the CoreBluetooth API's buffer fills and stops enqueuing Data to send.
      */
-    internal static let WRITE_VALUE_BUFFER_SIZE = 10
+    internal static let WRITE_VALUE_BUFFER_SIZE = 16
     /**
      The minimum amount of time we expect needs to elapse before the Write Without Response buffer is cleared in microseconds.
      


### PR DESCRIPTION
So, what is the write buffer size? We know the underlying CoreBluetooth API has a buffer to store all the Data we 'give it' to send to a CBPeripheral, but we don't know how big it is. If we ask CBPeripheral if it's ready to receive new Data, it almost always doesn't end up well. Perhaps we could do some further work to look into it. I might in fact, look into that next. But, regardless, increasing this number should hopefully prevent us from "waiting" and entering the spinlock scenario of waiting to hear back from CBPeripheral.