### PR TITLE
Change: McuMgrBleTransportWriteState now has an open() API for Error(s)

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -357,8 +357,9 @@ extension McuMgrBleTransport: McuMgrTransport {
             }
             
             guard dataChunksSize == data.count else {
-                writeState[sequenceNumber]?.writeLock.open(McuMgrTransportError.badChunking)
-                return .failure(McuMgrTransportError.badChunking)
+                let error = McuMgrTransportError.badChunking
+                writeState.open(sequenceNumber: sequenceNumber, dueTo: error)
+                return .failure(error)
             }
             
             coordinatedWrite(of: dataChunks, to: targetPeripheral, characteristic: smpCharacteristic) { [weak self] chunk, error in
@@ -373,8 +374,9 @@ extension McuMgrBleTransport: McuMgrTransport {
         } else {
             // No SMP Reassembly Supported. So no 'chunking'.
             guard data.count <= mtu else {
-                writeState[sequenceNumber]?.writeLock.open(McuMgrTransportError.insufficientMtu(mtu: mtu))
-                return .failure(McuMgrTransportError.insufficientMtu(mtu: mtu))
+                let error = McuMgrTransportError.insufficientMtu(mtu: mtu)
+                writeState.open(sequenceNumber: sequenceNumber, dueTo: error)
+                return .failure(error)
             }
             
             coordinatedWrite(of: [data], to: targetPeripheral, characteristic: smpCharacteristic) { [weak self] data, error in

--- a/Source/Bluetooth/McuMgrBleTransportWriteState.swift
+++ b/Source/Bluetooth/McuMgrBleTransportWriteState.swift
@@ -84,6 +84,12 @@ final class McuMgrBleTransportWriteState {
         }
     }
     
+    func open(sequenceNumber: McuSequenceNumber, dueTo error: McuMgrTransportError) {
+        lockingQueue.async {
+            self.state[sequenceNumber]?.writeLock.open(error)
+        }
+    }
+    
     func completedWrite(sequenceNumber: McuSequenceNumber) {
         lockingQueue.async {
             self.state[sequenceNumber] = nil


### PR DESCRIPTION
We can convert this API call into a 'sync' instead of 'async'. But in general, we should prefer 'async' calls instead of 'sync'. There's a reason why we went the 'sync' reason here which is, I presume, if there's an error we want to stop immediately and not do unnecessary work. We will do more testing to confirm whether this breaks anything or not.