### PR TITLE
Change: Limit Reassembly Buffer Size to fall within CoreBluetooth API Buffer

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -479,14 +479,14 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     /// state on success.
     private lazy var listCallback: McuMgrCallback<McuMgrImageStateResponse> = { [weak self] response, error in
         // Ensure the manager is not released.
-        guard let self = self else { return }
+        guard let self else { return }
         
         // Check for an error.
-        if let error = error {
+        if let error {
             self.fail(error: error)
             return
         }
-        guard let response = response else {
+        guard let response else {
             self.fail(error: FirmwareUpgradeError.unknown("Image List response is nil."))
             return
         }

--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -67,7 +67,7 @@ public class FileSystemManager: McuManager {
         
         // Get the length of file data to send.
         let maxReassemblySize = min(uploadConfiguration.reassemblyBufferSize, UInt64(UInt16.max))
-        let maxPacketSize = max(maxReassemblySize, UInt64(mtu))
+        let maxPacketSize = max(maxReassemblySize, UInt64(transport.mtu))
         var maxDataLength = maxPacketSize - UInt64(packetOverhead)
         if uploadConfiguration.byteAlignment != .disabled {
             maxDataLength = (maxDataLength / uploadConfiguration.byteAlignment.rawValue) * uploadConfiguration.byteAlignment.rawValue

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -240,6 +240,10 @@ public class ImageManager: McuManager {
         uploadConfiguration = configuration
         // Don't exceed UInt16.max payload size.
         uploadConfiguration.reassemblyBufferSize = min(uploadConfiguration.reassemblyBufferSize, UInt64(UInt16.max))
+        if uploadConfiguration.reassemblyBufferSize / UInt64(transport.mtu ?? 1) > McuMgrBleTransportConstant.WRITE_VALUE_BUFFER_SIZE {
+            uploadConfiguration.reassemblyBufferSize = UInt64(transport.mtu ?? 1) * UInt64(McuMgrBleTransportConstant.WRITE_VALUE_BUFFER_SIZE)
+            log(msg: "Lowered Reassembly Buffer Size to \(uploadConfiguration.reassemblyBufferSize) due to low MTU (too many Bluetooth API writes per buffer).", atLevel: .warning)
+        }
         
         uploadPipeline = McuMgrUploadPipeline(adopting: uploadConfiguration, over: transport)
         
@@ -558,7 +562,7 @@ public class ImageManager: McuManager {
         
         let remainingBytes = UInt64(data.count) - offset
         let packetOverhead = calculatePacketOverhead(data: data, image: image, offset: UInt64(offset))
-        let maxPacketSize = max(uploadConfiguration.reassemblyBufferSize, UInt64(mtu))
+        let maxPacketSize = max(uploadConfiguration.reassemblyBufferSize, UInt64(transport.mtu))
         var maxDataLength = maxPacketSize - UInt64(packetOverhead)
         if uploadConfiguration.byteAlignment != .disabled {
             maxDataLength = (maxDataLength / uploadConfiguration.byteAlignment.rawValue) * uploadConfiguration.byteAlignment.rawValue

--- a/Source/Managers/SuitManager.swift
+++ b/Source/Managers/SuitManager.swift
@@ -562,7 +562,7 @@ public class SuitManager: McuManager {
         
         let remainingBytes = UInt64(data.count) - offset
         let packetOverhead = calculatePacketOverhead(data: data, offset: offset)
-        let maxDataLength = UInt64(mtu) - UInt64(packetOverhead)
+        let maxDataLength = UInt64(transport.mtu) - UInt64(packetOverhead)
         return min(maxDataLength, remainingBytes)
     }
     

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -55,12 +55,6 @@ open class McuManager : NSObject {
     /// Manager.
     public let group: McuMgrGroup
     
-    /// The MTU used by this manager. This value must be between 23 and 1024.
-    /// The MTU is usually only a factor when uploading files or images to the
-    /// device, where each request should attempt to maximize the amount of
-    /// data being sent to the device.
-    public var mtu: Int
-    
     /// Logger delegate will receive logs.
     public weak var logDelegate: McuMgrLogDelegate?
     
@@ -83,7 +77,6 @@ open class McuManager : NSObject {
     public init(group: McuMgrGroup, transport: McuMgrTransport) {
         self.group = group
         self.transport = transport
-        self.mtu = McuManager.getDefaultMtu(scheme: transport.getScheme())
     }
     
     // MARK: - Send
@@ -228,11 +221,11 @@ open class McuManager : NSObject {
         guard Self.ValidMTURange.contains(mtu) else {
             throw McuManagerError.mtuValueOutsideOfValidRange(mtu)
         }
-        guard self.mtu != mtu else {
+        guard self.transport.mtu != mtu else {
             throw McuManagerError.mtuValueHasNotChanged(mtu)
         }
         
-        self.mtu = mtu
+        self.transport.mtu = mtu
         log(msg: "MTU set to \(mtu)", atLevel: .info)
     }
     

--- a/Source/McuMgrTransport.swift
+++ b/Source/McuMgrTransport.swift
@@ -97,6 +97,14 @@ extension McuMgrTransportError: LocalizedError {
 /// Mcu Mgr transport object. The transport object
 /// should automatically handle connection on first request.
 public protocol McuMgrTransport: AnyObject {
+    
+    /**
+     This value must be between 23 and 1024.
+     
+     MTU is usually only a factor when uploading files or images to the device, where each request should attempt to maximize the amount of data being sent to the device.
+     */
+    var mtu: Int! { get set }
+    
     /// Returns the transport scheme.
     ///
     /// - returns: The transport scheme.


### PR DESCRIPTION
The way we understand it at the moment, CoreBluetooth has an underlying buffer that accumulates all the Data passed to it via cbPeripheral "write" API calls. If we exceed this buffer, the Data passed-in to it is just lost. When we think we might hit this limit, we stop and ask the CBPeripheral if we think we can start writing again. Problem is, this almost always happens, as we have the code written now, in the middle of a buffer write. And the stall is for so long, that the firmware starts thinking we wrote the chunk of Data already. It's a mess. There are levers in the current API to fix this, like reducing the number of buffers, reassembly size, etc. But we want to keep the library / API more reliable, hence the nature of this change.