### PR TITLE
Fix for out-of-order Response(s) not allowing offset to grow

### DIFF
--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -456,7 +456,8 @@ public class ImageManager: McuManager {
         }
         
         if let offset = response.off {
-            self.uploadLastOffset = offset
+            // We might get called out-of-order so, always retain highest received offset.
+            self.uploadLastOffset = max(self.uploadLastOffset, offset)
             self.uploadPipeline.receivedData(with: offset)
             
             self.uploadDelegate?.uploadProgressDidChange(bytesSent: Int(self.uploadLastOffset), imageSize: currentImageData.count, timestamp: Date())


### PR DESCRIPTION
If we receive a lower offset, we might trigger the library to send Data it's already sent, which throws us in a loop we don't need to be in.