### PR TITLE
Fix for String API to insert a separator

### DIFF
--- a/Source/Extensions/String+McuManager.swift
+++ b/Source/Extensions/String+McuManager.swift
@@ -27,12 +27,14 @@ internal extension String {
     }
     
     func inserting(separator: String, every n: Int) -> String {
-        var result: String = ""
         let characters = Array(self)
-        stride(from: 0, to: characters.count, by: n).forEach {
-            result += String(characters[$0..<min($0 + n, characters.count)])
-            if $0 + n < characters.count {
-                result += separator
+        let addedSeparators: Int = characters.count / 4
+        var result: String = ""
+        result.reserveCapacity(characters.count + addedSeparators)
+        for i in stride(from: 0, to: characters.count, by: n) {
+            result.append(contentsOf: characters[i..<min(i + n, characters.count)])
+            if i + n < characters.count {
+                result.append(separator)
             }
         }
         return result


### PR DESCRIPTION
For-loops are more efficient than for-Each. We're also setting the size of the output String beforehand, to try to avoid new memory allocations.