### PR TITLE
Initial Support for NCS v2.9 "Compressed" Flag

### DIFF
--- a/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
+++ b/Example/Example/View Controllers/Manager/Widgets/ImagesViewController.swift
@@ -273,7 +273,10 @@ class ImagesViewController: UIViewController, McuMgrViewController {
             if image.permanent {
                 info += "Permanent, "
             }
-            if !image.bootable && !image.pending && !image.confirmed && !image.active && !image.permanent {
+            if image.compressed {
+                info += "Compressed, "
+            }
+            if !image.bootable && !image.pending && !image.confirmed && !image.active && !image.permanent && !image.compressed {
                 info += "None, "
             } else {
                 info = String(info.dropLast(2))

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -970,6 +970,8 @@ extension McuMgrImageStateResponse {
         public var active: Bool { boolean() }
         /// Permanent flag. Set if this image is permanent.
         public var permanent: Bool { boolean() }
+        // Compressed flag. Set if the image contains a compressed update.
+        public var compressed: Bool { boolean() }
         
         // MARK: CustomDebugStringConvertible
         
@@ -977,7 +979,7 @@ extension McuMgrImageStateResponse {
             return """
             Hash: \(hash)
             Image \(image), Slot \(slot), Version \(version)
-            Bootable \(bootable ? "Yes" : "No"), Pending \(pending ? "Yes" : "No"), Confirmed \(confirmed ? "Yes" : "No"), Active \(active ? "Yes" : "No"), Permanent \(permanent ? "Yes" : "No")
+            Bootable \(bootable ? "Yes" : "No"), Pending \(pending ? "Yes" : "No"), Confirmed \(confirmed ? "Yes" : "No"), Active \(active ? "Yes" : "No"), Compressed \(compressed ? "Yes" : "No"), Permanent \(permanent ? "Yes" : "No")
             """
         }
         


### PR DESCRIPTION
From NCS 2.9.0 onwardss, MCUBoot supports sending Compressed Images.