### PR TITLE
Fix for ZIP Package containing multiple ".json" files

### DIFF
--- a/Source/McuMgrPackage.swift
+++ b/Source/McuMgrPackage.swift
@@ -140,7 +140,9 @@ fileprivate extension McuMgrPackage {
         try fileManager.unzipItem(at: url, to: unzipLocationURL)
         let unzippedURLs = try fileManager.contentsOfDirectory(at: unzipLocationURL, includingPropertiesForKeys: nil, options: [])
         
-        guard let dfuManifestURL = unzippedURLs.first(where: { $0.pathExtension == "json" }) else {
+        guard let dfuManifestURL = unzippedURLs.first(where: {
+            $0.lastPathComponent == "manifest.json"
+        }) else {
             throw McuMgrPackage.Error.manifestFileNotFound
         }
         let manifest = try McuMgrManifest(from: dfuManifestURL)


### PR DESCRIPTION
We need to find the manifest by looking for "manifest.json" instead of by looking for the first "json" file.