### PR TITLE
Fixed SettingsManager.read response incorrectly mapped from CBOR string instead of byte string.

### DIFF
--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -1367,11 +1367,11 @@ public class McuMgrStatsListResponse: McuMgrResponse {
 public class McuMgrConfigResponse: McuMgrResponse {
     
     /// Config value.
-    public var val: String?
+    public var val: [UInt8]?
     
     public required init(cbor: CBOR?) throws {
         try super.init(cbor: cbor)
-        if case let CBOR.utf8String(val)? = cbor?["val"] {self.val = val}
+        if case let CBOR.byteString(val)? = cbor?["val"] {self.val = val}
     }
 }
 


### PR DESCRIPTION
# Fixed
- SettingsManager.read response is decoded as byte array instead of a utf8 string. 