### PR TITLE
Added Internal Soft Reset for McuMgrBleTransport

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
@@ -96,6 +96,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
         // Set the SMP characteristic.
         smpCharacteristic = characteristic
         state = .connected
+        softReset()
         notifyStateChanged(.connected)
         
         // The SMP Service and characteristic have now been discovered and set

--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -256,6 +256,16 @@ extension McuMgrBleTransport: McuMgrTransport {
         }
     }
     
+    /**
+     Clean any necessary state between Peripheral Connections.
+     
+     Multiple heavy-duty operations may be performed using the same 'transport' instance. To
+     prevent issues and attempt to improve reliability, it's better to wipe any lingering state.
+     */
+    internal func softReset() {
+        writeState = McuMgrBleTransportWriteState()
+    }
+    
     /// This method sends the data to the target. Before, it ensures that
     /// CBCentralManager is ready and the peripheral is connected.
     /// The peripheral will automatically be connected when it's not.


### PR DESCRIPTION
Customers of the API will probably, like nRF Connect, build a new transport for each DFU attempt. But it's possible others do like nRF Connect Device Manager, and keep reusing the same Transport. It's possible this affects the repeated DFU attempts with unclean state of private / internal properties. So we're going to try to get better at detecting new connections, and using those as an opportunity to reset internal variables that might need it.