### PR TITLE
Extended "Fast Timeout" Time from 5 to 10 seconds

### DIFF
--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -42,7 +42,7 @@ open class McuManager : NSObject {
     public static let DEFAULT_SEND_TIMEOUT_SECONDS = 40
     /// This is the default time to wait for a command to be sent, executed
     /// and received (responded to) by the firmware on the other end.
-    public static let FAST_TIMEOUT = 5
+    public static let FAST_TIMEOUT = 10
     
     //**************************************************************************
     // MARK: Properties


### PR DESCRIPTION
This is the time we wait for a response before issuing a retry. Retries can be... problematic, because they can start us down into a death spiral because the firmware might be busy and is about to reply, or perhaps, we haven't even sent that reassembly packet because we're having to wait due to BLE radio issues (Peripheral not ready to send write without response). This is a mess. I don't know if I'm fixing something or pretending I'm fixing something by writing a lot of code that looks smart, and then changing a magic number.