### PR TITLE
Rebuilt BLE Transport Layer

### DIFF
--- a/Source/Bluetooth/McuMgrBleROBWriteBuffer.swift
+++ b/Source/Bluetooth/McuMgrBleROBWriteBuffer.swift
@@ -1,0 +1,193 @@
+//
+//  McuMgrBleROBWriteBuffer.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 14/7/25.
+//
+
+import Foundation
+import Dispatch
+import CoreBluetooth
+
+// MARK: - McuMgrBleROBWriteBuffer
+
+/**
+ ROB for Re-Order Buffer.
+ 
+ The purpose of this last-level transport layer is to guarantee all chunks for the same
+ sequence number are sent in-order. If multiple pieces (chunks) of different sequence
+ numbers are interleaved, it'll garble up the results and the firmware will not be able to
+ understand anything.
+ */
+internal final class McuMgrBleROBWriteBuffer {
+    
+    // MARK: - Private Properties
+    
+    private let lock = DispatchQueue(label: "McuMgrBleROBWriteBuffer", qos: .userInitiated)
+    
+    private var pausedWritesWithoutResponse: Bool
+    private var window: [Write]
+    
+    private weak var log: McuMgrLogDelegate?
+    
+    // MARK: init
+    
+    init(_ log: McuMgrLogDelegate?) {
+        self.log = log
+        self.pausedWritesWithoutResponse = false
+        self.window = [Write]()
+    }
+    
+    // MARK: API
+    
+    internal func isInFlight(_ sequenceNumber: McuSequenceNumber) -> Bool {
+        lock.sync { [unowned self] in
+            return window.contains(where: {
+                $0.sequenceNumber == sequenceNumber
+            })
+        }
+    }
+    
+    /**
+     All chunks of the same packet need to be sent together. Otherwise, they can't be merged properly on the receiving end.
+     */
+    internal func enqueue(_ sequenceNumber: McuSequenceNumber, data: [Data], to peripheral: CBPeripheral, characteristic: CBCharacteristic, callback: @escaping (Data?, McuMgrTransportError?) -> Void) {
+        guard !isInFlight(sequenceNumber) else {
+            // Do not enqueue again if said sequence number is in-flight.
+            guard pausedWritesWithoutResponse else { return }
+            // Note that sometimes we will not get a "peripheralIsReadyForWriteWithoutResponse".
+            // The only way to move forward, is just to ask / try again to send.
+            pausedWritesWithoutResponse = false
+            let targetSequenceNumber: McuSequenceNumber! = window.first?.sequenceNumber
+            log(msg: "→ Continue [Seq. No: \(targetSequenceNumber)].", atLevel: .debug)
+            unsafe_fulfillEnqueuedWrites(to: peripheral, for: targetSequenceNumber)
+            return
+        }
+        
+        // This lock guarantees parallel writes are not interleaved with each other.
+        lock.async { [unowned self] in
+            window.append(contentsOf: Write.split(sequenceNumber: sequenceNumber, chunks: data, peripheral: peripheral, characteristic: characteristic, callback: callback))
+            window.sort(by: <)
+            
+            let targetSequenceNumber: McuSequenceNumber! = window.first?.sequenceNumber
+            unsafe_fulfillEnqueuedWrites(to: peripheral, for: targetSequenceNumber)
+        }
+    }
+    
+    internal func peripheralReadyToWrite(_ peripheral: CBPeripheral) {
+        lock.async { [unowned self] in
+            // Note: peripheralIsReady(toSendWriteWithoutResponse:) is called many times.
+            // We only want to continue past this guard when a write was paused and
+            // thus added to `pausedWrites`.
+            guard pausedWritesWithoutResponse else { return }
+            pausedWritesWithoutResponse = false
+            // Paused writes are never removed from the queue. So all we have to do is
+            // restart from the front of the queue.
+            let resumeWrite: Write! = window.first
+            log(msg: "► [Seq: \(resumeWrite.sequenceNumber), Chk: \(resumeWrite.chunkIndex)] Resume (Peripheral Ready for Write Without Response)", atLevel: .debug)
+            unsafe_fulfillEnqueuedWrites(to: peripheral, for: resumeWrite.sequenceNumber)
+        }
+    }
+}
+    
+// MARK: - Private
+
+private extension McuMgrBleROBWriteBuffer {
+    
+    func unsafe_fulfillEnqueuedWrites(to peripheral: CBPeripheral, for sequenceNumber: McuSequenceNumber) {
+        for write in window where write.sequenceNumber == sequenceNumber {
+            guard peripheral.canSendWriteWithoutResponse else {
+                log(msg: "⏸︎ [Seq: \(sequenceNumber), Chk: \(write.chunkIndex)] Paused (Peripheral not Ready for Write Without Response)", atLevel: .debug)
+                pausedWritesWithoutResponse = true
+                return
+            }
+            
+            if write.chunkIndex == 0 {
+                for (i, write) in window.enumerated() where write.sequenceNumber == sequenceNumber {
+                    #if DEBUG
+                    print("✈ [Seq: \(sequenceNumber), Chk: \(write.chunkIndex)]")
+                    #endif
+                    window[i].inFlight = true
+                }
+            }
+            
+            peripheral.writeValue(write.chunk, for: write.characteristic,
+                                  type: .withoutResponse)
+            write.callback(write.chunk, nil)
+            let i: Int! = window.firstIndex(of: write)
+            window.remove(at: i)
+        }
+    }
+    
+    func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
+        log?.log(msg(), ofCategory: .transport, atLevel: level)
+    }
+}
+
+// MARK: - Write
+
+internal extension McuMgrBleROBWriteBuffer {
+    
+    struct Write {
+        
+        let sequenceNumber: McuSequenceNumber
+        let chunkIndex: Int
+        let chunk: Data
+        let peripheral: CBPeripheral
+        let characteristic: CBCharacteristic
+        let callback: (Data?, McuMgrTransportError?) -> Void
+        var inFlight: Bool
+        
+        init(sequenceNumber: McuSequenceNumber, chunkIndex: Int, chunk: Data, peripheral: CBPeripheral, characteristic: CBCharacteristic, callback: @escaping (Data?, McuMgrTransportError?) -> Void) {
+            self.sequenceNumber = sequenceNumber
+            self.chunkIndex = chunkIndex
+            self.chunk = chunk
+            self.peripheral = peripheral
+            self.characteristic = characteristic
+            self.callback = callback
+            self.inFlight = false
+        }
+        
+        static func split(sequenceNumber: McuSequenceNumber, chunks: [Data], peripheral: CBPeripheral, characteristic: CBCharacteristic, callback: @escaping (Data?, McuMgrTransportError?) -> Void) -> [Self] {
+            return chunks.indices.map { i in
+                Self(sequenceNumber: sequenceNumber, chunkIndex: i, chunk: chunks[i], peripheral: peripheral, characteristic: characteristic, callback: callback)
+            }
+        }
+    }
+}
+
+// MARK: Comparable
+
+extension McuMgrBleROBWriteBuffer.Write: Comparable {
+    
+    /**
+     "In-flight" writes are higher priority within a given sequence number, since
+     the previous sequence number might've not completed its 'write' on resume.
+     If we reorder and switch to a different 'chunk' because of a retry operation,
+     the end result is a reassembly packet the firmware cannot reassemble.
+     */
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        guard lhs.inFlight == rhs.inFlight else {
+            // Whoever is "in-flight" wins
+            return lhs.inFlight
+        }
+        
+        if lhs.sequenceNumber == rhs.sequenceNumber {
+            return lhs.chunkIndex < rhs.chunkIndex
+        } else {
+            return lhs.sequenceNumber < rhs.sequenceNumber
+        }
+    }
+}
+
+// MARK: Equatable
+
+extension McuMgrBleROBWriteBuffer.Write: Equatable {
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.sequenceNumber == rhs.sequenceNumber
+            && lhs.chunkIndex == rhs.chunkIndex
+            && lhs.peripheral.identifier == rhs.peripheral.identifier
+            && lhs.characteristic.uuid == rhs.characteristic.uuid
+    }
+}

--- a/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
@@ -145,13 +145,6 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
     
     public func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
         // Restart any paused writes due to Peripheral not being ready for more writes.
-        writeState.sharedLock { [unowned self] in
-            guard !pausedWrites.isEmpty else { return }
-            for pausedWrite in pausedWrites {
-                log(msg: "► [Seq: \(pausedWrite.sequenceNumber)] Resume (Peripheral Ready for Write Without Response)", atLevel: .debug)
-                coordinatedWrite(of: pausedWrite.sequenceNumber, data: Array(pausedWrite.remaining), to: pausedWrite.peripheral, characteristic: pausedWrite.characteristic, callback: pausedWrite.callback)
-            }
-            pausedWrites.removeAll()
-        }
+        robWriteBuffer.peripheralReadyToWrite(peripheral)
     }
 }

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -66,9 +66,9 @@ open class McuManager : NSObject {
     private var nextSequenceNumber: McuSequenceNumber = .random()
     
     /**
-     Sequence Number Response ReOrder Buffer
+     Sequence Number Response OoO Buffer
      */
-    private var robBuffer = McuMgrROBBuffer<McuSequenceNumber, Any>()
+    private var oobBuffer = McuMgrCallbackOoOBuffer<McuSequenceNumber, Any>()
     
     //**************************************************************************
     // MARK: Initializers
@@ -107,8 +107,8 @@ open class McuManager : NSObject {
             }
             
             do {
-                guard try self.robBuffer.received((response, error), for: packetSequenceNumber) else { return }
-                try self.robBuffer.deliver { responseSequenceNumber, response in
+                guard try self.oobBuffer.received((response, error), for: packetSequenceNumber) else { return }
+                try self.oobBuffer.deliver { responseSequenceNumber, response in
                     let responseResult = response as? (T?, (any Error)?)
                     if let response = responseResult?.0 {
                         self.smpVersion = McuMgrVersion(rawValue: response.header.version) ?? .SMPv1
@@ -127,8 +127,8 @@ open class McuManager : NSObject {
             }
         }
         
-        robBuffer.logDelegate = logDelegate
-        robBuffer.enqueueExpectation(for: packetSequenceNumber)
+        oobBuffer.logDelegate = logDelegate
+        oobBuffer.enqueueExpectation(for: packetSequenceNumber)
         send(data: packetData, timeout: timeout, callback: _callback)
         // Use of Overflow operator
         nextSequenceNumber = nextSequenceNumber &+ 1

--- a/Source/McuMgrCallbackOoOBuffer.swift
+++ b/Source/McuMgrCallbackOoOBuffer.swift
@@ -1,5 +1,5 @@
 //
-//  McuMgrROBBuffer.swift
+//  McuMgrCallbackOoOBuffer.swift
 //  iOSMcuManagerLibrary
 //
 //  Created by Dinesh Harjani on 29/9/22.
@@ -9,12 +9,12 @@ import Foundation
 import Dispatch
 import os.log
 
-// MARK: - McuMgrROBBuffer<Key, Value>
+// MARK: - McuMgrCallbackOoOBuffer<Key, Value>
 
 /**
- <Key, Value> Re-Order Buffer.
+ <Key, Value> Out-of-Order Buffer.
  */
-public struct McuMgrROBBuffer<Key: Hashable & Comparable, Value> {
+public struct McuMgrCallbackOoOBuffer<Key: Hashable & Comparable, Value> {
     
     // MARK: BufferError
     
@@ -57,9 +57,7 @@ public struct McuMgrROBBuffer<Key: Hashable & Comparable, Value> {
      This function informs the buffer a `Value` has been received. If the
      buffer recommends proceeding with a call to get a value, which is
      through the `deliver(to:)` API, it will return true. If not, the buffer
-     is pending reception of values for a different key. Of course, you
-     can still call `deliver(to:)` if you'd like to, but then the buffer
-     might be missing values.
+     is pending reception of values for a different key.
      
      - returns: `true` if a subsequent call to `deliver(to:)` is suggested.
      */
@@ -70,7 +68,8 @@ public struct McuMgrROBBuffer<Key: Hashable & Comparable, Value> {
                     buffer[key] = value
                     log(msg: "Received missing OoO (Out of Order) Key \(key).", atLevel: .debug)
                     outOfOrderKeys.remove(key)
-                    return outOfOrderKeys.isEmpty
+                    // Deliver the received key.
+                    return true
                 } else {
                     throw BufferError.invalidKey(key)
                 }
@@ -127,7 +126,7 @@ public struct McuMgrROBBuffer<Key: Hashable & Comparable, Value> {
     }
 }
 
-private extension McuMgrROBBuffer {
+private extension McuMgrCallbackOoOBuffer {
     
     func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
         if let logDelegate, level >= logDelegate.minLogLevel() {

--- a/Source/McuMgrTransport.swift
+++ b/Source/McuMgrTransport.swift
@@ -64,6 +64,8 @@ public enum McuMgrTransportError: Error, Hashable {
     case badResponse
     /// Device is busy, so we sleep for a few seconds and try again.
     case waitAndRetry
+    /// Device BLE Radio not ready to accept more writes.
+    case peripheralNotReadyForWriteWithoutResponse
 }
 
 extension McuMgrTransportError: LocalizedError {
@@ -90,6 +92,8 @@ extension McuMgrTransportError: LocalizedError {
             return "Bad response received."
         case .waitAndRetry:
             return "Device Busy. Will retry after a short wait..."
+        case .peripheralNotReadyForWriteWithoutResponse:
+            return "Peripheral unable to receive Data over BLE. Have you tried reducing the number of buffers?"
         }
     }
 }


### PR DESCRIPTION
The previous "ROBBuffer", was never a ROB Buffer as such, since it did no reordering work. Instead, it tracked Out-of-Order buffer response callbacks, so we renamed it to reflect that. And instead, we wrote a new component below the McuMgrBleTransport, that does reordering of write operations, and henceforth does receive the "ROBWriteBuffer" name. The purpose of this change is to try to improve how we try to recover from "Peripheral is not ready for write without response" situations, or at the very least, not make things worse by retrying sequence numbers and losing the coherence of the packets we're sending. All packets we send, must follow their sequence number, so we cannot send chunk 0, 1 of Seq. 25, and then switch to Seq. 24 and send chunk 0 before finishing all chunks of Seq. 25 - it'll just throw off the firmware. And when we retry a previous sequence number, we can do so, but not "break" our current sequence of pending writes. This is... complicated.