### PR TITLE
Change: Always attempt to empty WriteROBBuffer "Window" on Writes

### DIFF
--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -572,8 +572,13 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
             !discardedImages.contains($0)
         })
         
-        // Validation successful, begin with image upload.
-        self.upload()
+        // If we start upload immediately the first sequence number chunks could be ignored
+        // by the firware and upload would not continue until after the first (long) timeout.
+        // So we introduce a delay. Ugh... Bluetooth.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            // Validation successful, begin with image upload.
+            self?.upload()
+        }
     }
     
     private func targetSlotMatch(for responseImage: McuMgrImageStateResponse.ImageSlot,


### PR DESCRIPTION
There are more changes here. For example, we no longer "order" or "reorder" enqueued writes by their sequence number. Because if we do so, we're going to mix writes from different Managers, because sequence numbers are random. So, the last "write" might have a lower sequence number than the first, but it might get reordered into being at the head of the window (queue). Trying to keep CPU ROB Buffer terminologies here.

Besides that, we no longer wait to get a write for a specific sequence number in order to perform a write. We just send all writes within the window until we hit the dreaded "peripheral is not ready" flag. And, we also addressed a possible issue of peripheralIsReady() getting an enqueued call, but then the enqueue() getting called first, and finding the flag in "ready" and thus emptying the buffer's window. Which is basically fulfilling the enqueued peripheralIsReady() call. So we had to watch for that.

Also, added #DEBUG markers to have a read on what's the timeout time for "peripheral is not ready".