### PR TITLE
Integrate nRF Memfault SDK and add nRF Cloud OTA support

### DIFF
--- a/Example/Example/Util/UIColor.swift
+++ b/Example/Example/Util/UIColor.swift
@@ -14,6 +14,12 @@ extension UIColor {
     
     static let zephyr: UIColor = #colorLiteral(red: 0.231372549, green: 0.2431372549, blue: 0.3058823529, alpha: 1)
     
+    static let nordicBlue: UIColor = #colorLiteral(red: 0, green: 0.5483048558, blue: 0.8252354264, alpha: 1)
+    
+    static let nordicGreen: UIColor = #colorLiteral(red: 0.298, green: 0.733, blue: 0.349, alpha: 1)
+    
+    static let nordicRed: UIColor = #colorLiteral(red: 0.961, green: 0.341, blue: 0.314, alpha: 1)
+    
     static var primary: UIColor {
         if #available(iOS 13.0, *) {
             return .label

--- a/Example/Example/View Controllers/Manager/NRFViewController.swift
+++ b/Example/Example/View Controllers/Manager/NRFViewController.swift
@@ -1,0 +1,1010 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import UIKit
+import iOSMcuManagerLibrary
+import CoreBluetooth
+
+class NRFViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, McuMgrViewController, DeviceStatusDelegate, FirmwareUpgradeDelegate {
+    
+    // MARK: - Properties
+    
+    private var tableView: UITableView!
+    private var checkUpdateButton: UIButton!
+    private var statusLabel: UILabel!
+    private var updateInfoLabel: UILabel!
+    private var installButton: UIButton!
+    private var activityIndicator: UIActivityIndicatorView!
+    private var footerView: UIView!
+    
+    // Table view cells
+    private var connectionStatusLabel: UILabel!
+    private var mdsServiceLabel: UILabel!
+    private var smpServiceLabel: UILabel!
+    private var mdsChunksLabel: UILabel!
+    private var projectKeyTextField: UITextField!
+    private var hardwareVersionTextField: UITextField!
+    private var softwareTypeTextField: UITextField!
+    private var disVersionLabel: UILabel!
+    private var smpVersionLabel: UILabel!
+    
+    private var imageManager: ImageManager!
+    private var memfaultOTAManager: MemfaultOTAManager?
+    private var mdsManager: MemfaultManager!
+    private var currentVersion: String? // DIS version
+    private var smpVersion: String? // SMP version from image list
+    private var updateInfo: MemfaultOTAManager.UpdateInfo?
+    private var hasCheckedForUpdate: Bool = false
+    private var hasMDSService: Bool = false
+    private var hasSMPService: Bool = false
+    private var hasCheckedCapabilities: Bool = false
+    private var chunksReceived: Int = 0
+    private var chunksForwarded: Int = 0
+    private var isStreamingMDS: Bool = false
+    private var firmwareUpgradeManager: FirmwareUpgradeManager?
+    private var waitingForReconnectAfterUpdate: Bool = false
+    
+    var transport: McuMgrTransport! {
+        didSet {
+            if transport != nil {
+                imageManager = ImageManager(transport: transport)
+                imageManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
+            } else {
+            }
+        }
+    }
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupMDSManager()
+        
+        // Clear incorrect cached software type if it's a model number
+        let defaults = UserDefaults.standard
+        if let storedType = defaults.string(forKey: "memfault_software_type"),
+           (storedType == "nrf5340" || storedType == "nrf52840" || storedType == "nrf53") {
+            // These are model numbers, not software types - clear it
+            defaults.removeObject(forKey: "memfault_software_type")
+        }
+        
+        loadStoredProjectInfo()
+        
+        // Create and set up table view
+        tableView = UITableView(frame: view.bounds, style: .grouped)
+        tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 44
+        view.addSubview(tableView)
+        
+        // Create UI elements
+        checkUpdateButton = UIButton(type: .system)
+        checkUpdateButton.setTitle("Check for Updates", for: .normal)
+        checkUpdateButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .medium)
+        checkUpdateButton.backgroundColor = UIColor.nordicBlue
+        checkUpdateButton.setTitleColor(.white, for: .normal)
+        checkUpdateButton.layer.cornerRadius = 8
+        checkUpdateButton.translatesAutoresizingMaskIntoConstraints = false
+        checkUpdateButton.addTarget(self, action: #selector(checkForUpdates), for: .touchUpInside)
+        checkUpdateButton.isEnabled = false
+        
+        statusLabel = UILabel()
+        statusLabel.textAlignment = .center
+        statusLabel.numberOfLines = 0
+        statusLabel.font = .systemFont(ofSize: 14)
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.isHidden = true
+        
+        updateInfoLabel = UILabel()
+        updateInfoLabel.textAlignment = .center
+        updateInfoLabel.numberOfLines = 0
+        updateInfoLabel.font = .systemFont(ofSize: 14)
+        updateInfoLabel.translatesAutoresizingMaskIntoConstraints = false
+        updateInfoLabel.isHidden = true
+        
+        installButton = UIButton(type: .system)
+        installButton.setTitle("Install Update", for: .normal)
+        installButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .medium)
+        installButton.backgroundColor = UIColor.nordicGreen
+        installButton.setTitleColor(.white, for: .normal)
+        installButton.layer.cornerRadius = 8
+        installButton.translatesAutoresizingMaskIntoConstraints = false
+        installButton.addTarget(self, action: #selector(installUpdate), for: .touchUpInside)
+        installButton.isHidden = true
+        
+        if #available(iOS 13.0, *) {
+            activityIndicator = UIActivityIndicatorView(style: .medium)
+        } else {
+            activityIndicator = UIActivityIndicatorView(style: .gray)
+        }
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.hidesWhenStopped = true
+        
+        // Set initial footer
+        updateTableFooter()
+        
+        fetchCurrentVersion()
+    }
+    
+    private var hasInitialized = false
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if let parent = parent?.parent as? BaseViewController {
+            parent.deviceStatusDelegate = self
+            
+            // Initialize state
+            if let state = parent.state, state == .connected && !hasInitialized {
+                hasInitialized = true
+                // Clear previous state
+                hasMDSService = false
+                hasSMPService = false
+                hasCheckedCapabilities = false
+                hasCheckedForUpdate = false
+                
+                // Small delay to allow MDS service discovery before detecting capabilities
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    // Force table reload to ensure consistent state
+                    self.tableView.reloadData()
+                    
+                    // Detect device capabilities and fetch version
+                    self.detectDeviceCapabilities()
+                }
+            }
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Stop MDS streaming when leaving the view
+        if isStreamingMDS {
+            stopMDSStreaming()
+        }
+        
+        // Save any entered project info
+        saveProjectInfo()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Table View Data Source
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2 // Device Info, MDS Status
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case 0: // Device Info
+            return 8 // Connection, SMP Service, SMP Version, MDS Service, Project Key, Hardware Version, Software Type, DIS Version
+        case 1: // MDS Status
+            return hasMDSService ? 1 : 0
+        default:
+            return 0
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch section {
+        case 0:
+            return "Device Information"
+        case 1:
+            return hasMDSService ? "Monitoring & Diagnostic Service" : nil
+        default:
+            return nil
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: "Cell")
+        
+        switch indexPath.section {
+        case 0: // Device Info
+            switch indexPath.row {
+            case 0:
+                cell.textLabel?.text = "Connection"
+                if connectionStatusLabel == nil {
+                    connectionStatusLabel = UILabel()
+                }
+                connectionStatusLabel.text = state?.description ?? "Disconnected"
+                cell.detailTextLabel?.text = connectionStatusLabel.text
+            case 1:
+                cell.textLabel?.text = "SMP Service"
+                if smpServiceLabel == nil {
+                    smpServiceLabel = UILabel()
+                }
+                smpServiceLabel.text = hasSMPService ? "Available" : "Not Available"
+                smpServiceLabel.textColor = hasSMPService ? UIColor.nordicGreen : .systemRed
+                cell.detailTextLabel?.text = smpServiceLabel.text
+                cell.detailTextLabel?.textColor = smpServiceLabel.textColor
+            case 2:
+                cell.textLabel?.text = "Software Version (SMP)"
+                if smpVersionLabel == nil {
+                    smpVersionLabel = UILabel()
+                }
+                smpVersionLabel.text = smpVersion ?? "..."
+                cell.detailTextLabel?.text = smpVersionLabel.text
+            case 3:
+                cell.textLabel?.text = "MDS Service"
+                if mdsServiceLabel == nil {
+                    mdsServiceLabel = UILabel()
+                }
+                mdsServiceLabel.text = hasMDSService ? "Available" : "Not Available"
+                mdsServiceLabel.textColor = hasMDSService ? UIColor.nordicGreen : .systemRed
+                cell.detailTextLabel?.text = mdsServiceLabel.text
+                cell.detailTextLabel?.textColor = mdsServiceLabel.textColor
+            case 4:
+                cell.textLabel?.text = "Project Key"
+                cell.selectionStyle = .none
+                if projectKeyTextField == nil {
+                    projectKeyTextField = UITextField()
+                    projectKeyTextField.placeholder = "Enter Memfault Project Key"
+                    projectKeyTextField.textAlignment = .right
+                    projectKeyTextField.font = .systemFont(ofSize: 17)
+                    projectKeyTextField.addTarget(self, action: #selector(projectInfoChanged), for: .editingChanged)
+                    projectKeyTextField.text = UserDefaults.standard.string(forKey: "memfault_project_key")
+                }
+                projectKeyTextField.frame = CGRect(x: 0, y: 0, width: 200, height: 44)
+                cell.accessoryView = projectKeyTextField
+            case 5:
+                cell.textLabel?.text = "Hardware Version"
+                cell.selectionStyle = .none
+                if hardwareVersionTextField == nil {
+                    hardwareVersionTextField = UITextField()
+                    hardwareVersionTextField.placeholder = "e.g., nrf52840dk"
+                    hardwareVersionTextField.textAlignment = .right
+                    hardwareVersionTextField.font = .systemFont(ofSize: 17)
+                    hardwareVersionTextField.addTarget(self, action: #selector(projectInfoChanged), for: .editingChanged)
+                    hardwareVersionTextField.text = UserDefaults.standard.string(forKey: "memfault_hardware_version") ?? "nrf52840dk"
+                }
+                hardwareVersionTextField.frame = CGRect(x: 0, y: 0, width: 150, height: 44)
+                cell.accessoryView = hardwareVersionTextField
+            case 6:
+                cell.textLabel?.text = "Software Type"
+                cell.selectionStyle = .none
+                if softwareTypeTextField == nil {
+                    softwareTypeTextField = UITextField()
+                    softwareTypeTextField.placeholder = "e.g., main"
+                    softwareTypeTextField.textAlignment = .right
+                    softwareTypeTextField.font = .systemFont(ofSize: 17)
+                    softwareTypeTextField.addTarget(self, action: #selector(projectInfoChanged), for: .editingChanged)
+                    softwareTypeTextField.text = UserDefaults.standard.string(forKey: "memfault_software_type") ?? "main"
+                }
+                softwareTypeTextField.frame = CGRect(x: 0, y: 0, width: 150, height: 44)
+                cell.accessoryView = softwareTypeTextField
+            case 7:
+                cell.textLabel?.text = "Software Version (DIS)"
+                if disVersionLabel == nil {
+                    disVersionLabel = UILabel()
+                }
+                disVersionLabel.text = currentVersion ?? "..."
+                cell.detailTextLabel?.text = disVersionLabel.text
+            default:
+                break
+            }
+        case 1: // MDS Status
+            cell.textLabel?.text = "Status"
+            if mdsChunksLabel == nil {
+                mdsChunksLabel = UILabel()
+            }
+            mdsChunksLabel.text = "Chunks - Received: \(chunksReceived), Forwarded: \(chunksForwarded)"
+            cell.detailTextLabel?.text = mdsChunksLabel.text
+        default:
+            break
+        }
+        
+        return cell
+    }
+    
+    private var state: PeripheralState? {
+        if let parent = parent?.parent as? BaseViewController {
+            return parent.state
+        }
+        return nil
+    }
+    
+    // MARK: - MDS Setup and Management
+    
+    private func setupMDSManager() {
+        // Only create a new manager if one doesn't exist
+        if mdsManager == nil {
+            mdsManager = MemfaultManager()
+        }
+        
+        // Set callbacks
+        mdsManager.onDeviceConnected = { [weak self] device in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                
+                // MDS is already detected in detectDeviceCapabilities
+                // Just reset counters and start streaming
+                self.chunksReceived = 0
+                self.chunksForwarded = 0
+                
+                // Auto-start streaming when MDS is available
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    if !self.isStreamingMDS {
+                        print("NRFViewController: Starting MDS streaming")
+                        self.startMDSStreaming()
+                    } else {
+                        print("NRFViewController: MDS streaming already active")
+                    }
+                }
+            }
+        }
+        
+        mdsManager.onChunkReceived = { [weak self] chunk in
+            DispatchQueue.main.async {
+                print("NRFViewController: Chunk received, total: \(self?.chunksReceived ?? 0) + 1")
+                self?.chunksReceived += 1
+                self?.updateChunksUI()
+            }
+        }
+        
+        mdsManager.onChunkUploaded = { [weak self] chunk in
+            DispatchQueue.main.async {
+                self?.chunksForwarded += 1
+                self?.updateChunksUI()
+            }
+        }
+        
+        mdsManager.onError = { [weak self] error in
+            DispatchQueue.main.async {
+                self?.showError("MDS Error: \(error.localizedDescription)")
+            }
+        }
+        
+        mdsManager.onDeviceInfoUpdated = { [weak self] device in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                
+                // Update text fields with DIS values
+                if let hardwareVersion = device.hardwareRevision {
+                    self.hardwareVersionTextField?.text = hardwareVersion
+                }
+                // Don't use model number for software type - it should remain as configured
+                // The software revision is used for version display
+                if let softwareRevision = device.firmwareRevision {
+                    self.currentVersion = softwareRevision
+                }
+                // Update project key if available from MDS
+                if let projectKey = device.projectKey, !projectKey.isEmpty {
+                    self.projectKeyTextField?.text = projectKey
+                }
+                
+                // Don't reload table rows here - just save the values
+                // The table will show updated values when cells are recreated
+            }
+        }
+        
+        // Check if already connected
+        if let parent = parent?.parent as? BaseViewController,
+           let transport = transport as? McuMgrBleTransport,
+           let peripheral = transport.connectedPeripheral,
+           parent.state == .connected {
+            mdsManager.connectToDevice(peripheral: peripheral, transport: transport)
+        }
+    }
+    
+    private func updateChunksUI() {
+        // Update the MDS status cell directly without reloading
+        if hasMDSService && tableView.numberOfRows(inSection: 1) > 0 {
+            if let cell = tableView.cellForRow(at: IndexPath(row: 0, section: 1)) {
+                cell.detailTextLabel?.text = "Chunks - Received: \(chunksReceived), Forwarded: \(chunksForwarded)"
+            }
+        }
+    }
+    
+    
+    private func startMDSStreaming() {
+        guard hasMDSService else { return }
+        
+        isStreamingMDS = true
+        mdsManager.startDataStreaming()
+    }
+    
+    private func stopMDSStreaming() {
+        guard hasMDSService else { return }
+        
+        isStreamingMDS = false
+        mdsManager.stopDataStreaming()
+    }
+    
+    // MARK: - Device Capabilities Detection
+    
+    private func detectDeviceCapabilities() {
+        guard !hasCheckedCapabilities else {
+            return
+        }
+        
+        hasCheckedCapabilities = true
+        
+        // Check for MDS service
+        if let transport = transport as? McuMgrBleTransport,
+           let peripheral = transport.connectedPeripheral {
+            let mdsAvailable = transport.mdsService != nil
+            let smpAvailable = transport.hasSMPService
+            
+            // Update the flags
+            hasMDSService = mdsAvailable
+            hasSMPService = smpAvailable
+            
+            // Update button state
+            checkUpdateButton.isEnabled = smpAvailable && !(projectKeyTextField?.text?.isEmpty ?? true)
+            
+            // Connect MDS if available (this will trigger its own callbacks)
+            if mdsAvailable && mdsManager != nil {
+                print("NRFViewController: Connecting MDS manager to device")
+                mdsManager.connectToDevice(peripheral: peripheral, transport: transport)
+            } else {
+                print("NRFViewController: MDS not available or manager is nil. mdsAvailable: \(mdsAvailable), mdsManager: \(mdsManager != nil ? "exists" : "nil")")
+            }
+            
+            // Update table view for initial capabilities
+            tableView.reloadData()
+        }
+        
+        // Fetch current version only once
+        if !hasCheckedForUpdate {
+            fetchCurrentVersion()
+        }
+    }
+    
+    private func updateUIForDeviceCapabilities() {
+        // Just update the button state, don't reload table view
+        checkUpdateButton.isEnabled = hasSMPService && !(projectKeyTextField?.text?.isEmpty ?? true)
+    }
+    
+    // MARK: - Version Management
+    
+    private func fetchCurrentVersion(allowDISWait: Bool = false) {
+        
+        if allowDISWait {
+            // Wait briefly to allow DIS discovery
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?._fetchCurrentVersionInternal()
+            }
+        } else {
+            _fetchCurrentVersionInternal()
+        }
+    }
+    
+    private func _fetchCurrentVersionInternal() {
+        currentVersion = nil
+        smpVersion = nil
+        // Don't reload here - will reload when version is fetched
+        
+        // Always fetch both versions
+        fetchDISVersion()
+        fetchVersionViaSMP()
+    }
+    
+    private func fetchDISVersion() {
+        // Try DIS if available
+        if let transport = transport as? McuMgrBleTransport,
+           let peripheral = transport.connectedPeripheral,
+           let disService = transport.disService {
+            
+            // Look for software revision characteristic
+            if let softwareRevChar = disService.characteristics?.first(where: { $0.uuid == CBUUID(string: "2A28") }) {
+                // Check if the value is already cached
+                if let value = softwareRevChar.value,
+                   let version = String(data: value, encoding: .utf8),
+                   !version.isEmpty {
+                    self.currentVersion = version
+                    // Update the DIS version cell if visible
+                    if let cell = self.tableView.cellForRow(at: IndexPath(row: 7, section: 0)) {
+                        cell.detailTextLabel?.text = version
+                    }
+                    self.checkForUpdateIfNeeded()
+                } else {
+                    // Read the value
+                    peripheral.readValue(for: softwareRevChar)
+                    
+                    // Set up a notification observer for DIS updates
+                    NotificationCenter.default.addObserver(
+                        self,
+                        selector: #selector(disValueUpdated(_:)),
+                        name: .init("DISValueUpdated"),
+                        object: nil
+                    )
+                }
+            }
+        }
+    }
+    
+    @objc private func disValueUpdated(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let characteristicUUID = userInfo["uuid"] as? String,
+              characteristicUUID == "2A28",
+              let value = userInfo["value"] as? Data,
+              let version = String(data: value, encoding: .utf8),
+              !version.isEmpty else { return }
+        
+        self.currentVersion = version
+        
+        // Update the DIS version cell if visible
+        if let cell = self.tableView.cellForRow(at: IndexPath(row: 7, section: 0)) {
+            cell.detailTextLabel?.text = version
+        }
+        
+        // If we're waiting for reconnect after update, also reload the table to show new version
+        if waitingForReconnectAfterUpdate {
+            tableView.reloadRows(at: [IndexPath(row: 7, section: 0)], with: .none)
+        }
+        
+        self.checkForUpdateIfNeeded()
+        
+        // Remove observer after receiving the value
+        NotificationCenter.default.removeObserver(self, name: .init("DISValueUpdated"), object: nil)
+    }
+    
+    private func fetchVersionViaSMP() {
+        guard let imageManager = imageManager else {
+            smpVersion = nil
+            return
+        }
+        
+        
+        imageManager.list { [weak self] response, error in
+            DispatchQueue.main.async {
+                if error != nil {
+                    self?.smpVersion = nil
+                    return
+                }
+                
+                if let images = response?.images, !images.isEmpty {
+                    // Get the active image version
+                    if let activeImage = images.first(where: { $0.active }) {
+                        let version = activeImage.version
+                        self?.smpVersion = version
+                        // Update the SMP version cell if visible
+                        if let cell = self?.tableView.cellForRow(at: IndexPath(row: 2, section: 0)) {
+                            cell.detailTextLabel?.text = version
+                        }
+                        // If we're waiting for reconnect after update, also reload the table to show new version
+                        if self?.waitingForReconnectAfterUpdate ?? false {
+                            self?.tableView.reloadRows(at: [IndexPath(row: 2, section: 0)], with: .none)
+                        }
+                        // Also set currentVersion if DIS version is not available
+                        if self?.currentVersion == nil {
+                            self?.currentVersion = version
+                        }
+                        self?.checkForUpdateIfNeeded()
+                    } else if let firstImage = images.first {
+                        // Fallback to first image if no active image
+                        let version = firstImage.version
+                        self?.smpVersion = version
+                        // Update the SMP version cell if visible
+                        if let cell = self?.tableView.cellForRow(at: IndexPath(row: 2, section: 0)) {
+                            cell.detailTextLabel?.text = version
+                        }
+                        // If we're waiting for reconnect after update, also reload the table to show new version
+                        if self?.waitingForReconnectAfterUpdate ?? false {
+                            self?.tableView.reloadRows(at: [IndexPath(row: 2, section: 0)], with: .none)
+                        }
+                        // Also set currentVersion if DIS version is not available
+                        if self?.currentVersion == nil {
+                            self?.currentVersion = version
+                        }
+                        self?.checkForUpdateIfNeeded()
+                    }
+                } else {
+                    self?.smpVersion = nil
+                }
+            }
+        }
+    }
+    
+    // MARK: - Update Management
+    
+    @objc private func projectInfoChanged() {
+        saveProjectInfo()
+        checkUpdateButton.isEnabled = hasSMPService && !(projectKeyTextField?.text?.isEmpty ?? true)
+    }
+    
+    private func loadStoredProjectInfo() {
+        // These will be loaded when the cells are created
+        // We'll read from defaults when creating the cells
+    }
+    
+    private func saveProjectInfo() {
+        let defaults = UserDefaults.standard
+        defaults.set(projectKeyTextField?.text, forKey: "memfault_project_key")
+        defaults.set(hardwareVersionTextField?.text, forKey: "memfault_hardware_version")
+        defaults.set(softwareTypeTextField?.text, forKey: "memfault_software_type")
+    }
+    
+    private func checkForUpdateIfNeeded() {
+        // Only auto-check if we haven't checked yet and have all required info
+        if !hasCheckedForUpdate && currentVersion != nil && !(projectKeyTextField?.text?.isEmpty ?? true) {
+            // Auto-check for updates
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.checkForUpdates()
+            }
+        }
+    }
+    
+    @objc private func checkForUpdates() {
+        guard let projectKey = projectKeyTextField?.text, !projectKey.isEmpty else {
+            showError("Please enter your Memfault Project Key")
+            return
+        }
+        
+        guard let currentVersion = currentVersion else {
+            showError("Could not determine current version")
+            return
+        }
+        
+        hasCheckedForUpdate = true
+        
+        statusLabel.text = "Checking for updates..."
+        statusLabel.textColor = UIColor.primary
+        statusLabel.isHidden = false
+        checkUpdateButton.isEnabled = false
+        activityIndicator.startAnimating()
+        
+        let hardwareVersion = hardwareVersionTextField?.text ?? "nrf52840dk"
+        let softwareType = softwareTypeTextField?.text ?? "main"
+        
+        memfaultOTAManager = MemfaultOTAManager(
+            projectKey: projectKey,
+            hardwareVersion: hardwareVersion,
+            softwareType: softwareType
+        )
+        
+        memfaultOTAManager?.checkForUpdate(currentVersion: currentVersion, completion: { [weak self] (result) in
+            DispatchQueue.main.async {
+                // Ensure all UI updates happen on main thread
+                self?.activityIndicator.stopAnimating()
+                self?.checkUpdateButton.isEnabled = true
+                
+                switch result {
+            case .success(let updateInfo):
+                if let update = updateInfo {
+                    self?.updateInfo = update
+                    self?.statusLabel.textColor = UIColor.nordicGreen
+                    self?.statusLabel.text = "Update available!"
+                    self?.updateInfoLabel.text = "New version: \(update.version)\n\(update.releaseNotes ?? "")"
+                    self?.updateInfoLabel.isHidden = false
+                    self?.installButton.isHidden = false
+                    // Create and set a new footer view with update info
+                    self?.updateTableFooter()
+                } else {
+                    self?.statusLabel.textColor = UIColor.nordicBlue
+                    self?.statusLabel.text = "You're running the latest version"
+                    self?.updateInfoLabel.isHidden = true
+                    self?.installButton.isHidden = true
+                }
+                
+            case .failure(let error):
+                self?.statusLabel.textColor = UIColor.nordicRed
+                switch error {
+                case .invalidProjectKey:
+                    self?.statusLabel.text = "Invalid or missing project key"
+                case .networkError(let underlyingError):
+                    self?.statusLabel.text = "Network error: \(underlyingError.localizedDescription)"
+                case .invalidResponse(let details):
+                    self?.statusLabel.text = details ?? "Invalid response from server"
+                case .noUpdateAvailable:
+                    self?.statusLabel.textColor = UIColor.nordicBlue
+                    self?.statusLabel.text = "You're running the latest version"
+                }
+                self?.updateInfoLabel.isHidden = true
+                self?.installButton.isHidden = true
+            }
+            }
+        })
+    }
+    
+    @objc private func installUpdate() {
+        guard let updateInfo = updateInfo else { return }
+        
+        installButton.isEnabled = false
+        statusLabel.text = "Downloading firmware..."
+        statusLabel.textColor = UIColor.primary
+        
+        memfaultOTAManager?.downloadFirmware(from: updateInfo.downloadUrl, progress: { [weak self] progress in
+            DispatchQueue.main.async {
+                self?.statusLabel.text = String(format: "Downloading: %.0f%%", progress * 100)
+            }
+        }, completion: { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let data):
+                    self?.statusLabel.text = "Download complete"
+                    self?.startFirmwareUpgrade(with: data)
+                    
+                case .failure(let error):
+                    self?.statusLabel.textColor = UIColor.nordicRed
+                    self?.statusLabel.text = "Download failed: \(error.localizedDescription)"
+                    self?.installButton.isEnabled = true
+                }
+            }
+        })
+    }
+    
+    private func startFirmwareUpgrade(with data: Data) {
+        guard let transport = transport else {
+            showError("Transport not available")
+            return
+        }
+        
+        do {
+            let tempURL = try FirmwareFormatDetector.saveFirmwareToTemporaryFile(data)
+            let package = try McuMgrPackage(from: tempURL)
+            
+            firmwareUpgradeManager = FirmwareUpgradeManager(transport: transport, delegate: self)
+            firmwareUpgradeManager?.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
+            
+            statusLabel.text = "Starting firmware upgrade..."
+            statusLabel.textColor = UIColor.primary
+            
+            firmwareUpgradeManager?.start(package: package)
+            
+        } catch {
+            statusLabel.textColor = UIColor.nordicRed
+            statusLabel.text = "Failed to start upgrade: \(error.localizedDescription)"
+            installButton.isEnabled = true
+        }
+    }
+    
+    private func updateTableFooter() {
+        // Remove existing constraints first
+        checkUpdateButton.removeFromSuperview()
+        statusLabel.removeFromSuperview()
+        activityIndicator.removeFromSuperview()
+        updateInfoLabel.removeFromSuperview()
+        installButton.removeFromSuperview()
+        
+        // Create new footer view with correct size
+        let footerHeight: CGFloat = updateInfo != nil ? 200 : 120
+        let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: footerHeight))
+        
+        // Re-add check button
+        footerContainer.addSubview(checkUpdateButton)
+        footerContainer.addSubview(statusLabel)
+        footerContainer.addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            checkUpdateButton.leadingAnchor.constraint(equalTo: footerContainer.leadingAnchor, constant: 20),
+            checkUpdateButton.trailingAnchor.constraint(equalTo: footerContainer.trailingAnchor, constant: -20),
+            checkUpdateButton.topAnchor.constraint(equalTo: footerContainer.topAnchor, constant: 20),
+            checkUpdateButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            statusLabel.leadingAnchor.constraint(equalTo: footerContainer.leadingAnchor, constant: 20),
+            statusLabel.trailingAnchor.constraint(equalTo: footerContainer.trailingAnchor, constant: -20),
+            statusLabel.topAnchor.constraint(equalTo: checkUpdateButton.bottomAnchor, constant: 10),
+            
+            activityIndicator.centerXAnchor.constraint(equalTo: checkUpdateButton.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: checkUpdateButton.centerYAnchor)
+        ])
+        
+        // Add update info and install button if update is available
+        if updateInfo != nil {
+            footerContainer.addSubview(updateInfoLabel)
+            footerContainer.addSubview(installButton)
+            
+            NSLayoutConstraint.activate([
+                updateInfoLabel.leadingAnchor.constraint(equalTo: footerContainer.leadingAnchor, constant: 20),
+                updateInfoLabel.trailingAnchor.constraint(equalTo: footerContainer.trailingAnchor, constant: -20),
+                updateInfoLabel.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 10),
+                
+                installButton.leadingAnchor.constraint(equalTo: footerContainer.leadingAnchor, constant: 20),
+                installButton.trailingAnchor.constraint(equalTo: footerContainer.trailingAnchor, constant: -20),
+                installButton.topAnchor.constraint(equalTo: updateInfoLabel.bottomAnchor, constant: 10),
+                installButton.heightAnchor.constraint(equalToConstant: 44)
+            ])
+        }
+        
+        tableView.tableFooterView = footerContainer
+    }
+    
+    private func showError(_ message: String) {
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+    
+    // MARK: - DeviceStatusDelegate
+    
+    func connectionStateDidChange(_ state: PeripheralState) {
+        
+        if state == .connected && !hasInitialized {
+            hasInitialized = true
+            // Clear previous state
+            hasMDSService = false
+            hasSMPService = false
+            hasCheckedCapabilities = false
+            hasCheckedForUpdate = false
+            
+            // Small delay to allow MDS service discovery before detecting capabilities
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                // Detect device capabilities and fetch version
+                self.detectDeviceCapabilities()
+            }
+            
+            // Delay version fetch to allow DIS to be discovered first
+            fetchCurrentVersion(allowDISWait: true)
+        } else if state == .connected && hasInitialized {
+            // Check if we're reconnecting after a firmware update
+            if waitingForReconnectAfterUpdate {
+                waitingForReconnectAfterUpdate = false
+                
+                // Reset MDS state for the reconnected device
+                if mdsManager != nil {
+                    // Clear the connected device to force fresh discovery
+                    mdsManager.disconnect()
+                    // Reset our tracking variables
+                    hasMDSService = false
+                    chunksReceived = 0
+                    chunksForwarded = 0
+                    isStreamingMDS = false
+                    updateChunksUI()
+                    // Don't recreate the manager - just reset the state
+                    // The existing manager will be reconnected when detectDeviceCapabilities is called
+                }
+                
+                // Wait a bit for services to be discovered, then fetch new version
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                    self?.statusLabel.text = "Verifying update..."
+                    self?.statusLabel.textColor = UIColor.primary
+                    // Clear the version and force a fresh check
+                    self?.currentVersion = nil
+                    self?.smpVersion = nil
+                    self?.hasCheckedCapabilities = false
+                    
+                    // Re-detect capabilities which will fetch the new version
+                    self?.detectDeviceCapabilities()
+                    self?.fetchCurrentVersion(allowDISWait: true)
+                    
+                    // After fetching versions, show success
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+                        self?.checkUpdateButton.setTitle("Check for Updates", for: .normal)
+                        self?.checkUpdateButton.isEnabled = true
+                        self?.statusLabel.text = "Update confirmed!"
+                        self?.statusLabel.textColor = UIColor.nordicGreen
+                        
+                        // Clear the waiting flag
+                        self?.waitingForReconnectAfterUpdate = false
+                        
+                        // Hide the status after a delay
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+                            self?.statusLabel.isHidden = true
+                            self?.updateTableFooter()
+                        }
+                    }
+                }
+            } else {
+            }
+        } else {
+            // Reset state when disconnected
+            if state == .disconnected {
+                hasInitialized = false
+                hasCheckedForUpdate = false
+                hasMDSService = false
+                hasSMPService = false
+                hasCheckedCapabilities = false
+                currentVersion = nil
+                updateUIForDeviceCapabilities()
+            }
+        }
+    }
+    
+    func bootloaderNameReceived(_ name: String) {
+        // Not needed for this implementation
+    }
+    
+    func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode) {
+        // Not needed for this implementation
+    }
+    
+    func bootloaderSlotReceived(_ slot: UInt64) {
+        // Not needed for this implementation
+    }
+    
+    func appInfoReceived(_ output: String) {
+        // Not needed for this implementation
+    }
+    
+    func mcuMgrParamsReceived(buffers: Int, size: Int) {
+        // Not needed for this implementation
+    }
+    
+    // MARK: - FirmwareUpgradeDelegate
+    
+    func upgradeDidStart(controller: FirmwareUpgradeController) {
+        // Not needed for this implementation
+    }
+    
+    func upgradeDidComplete() {
+        // Not needed for this implementation
+    }
+    
+    func upgradeStateDidChange(from previousState: FirmwareUpgradeState, to newState: FirmwareUpgradeState) {
+        DispatchQueue.main.async { [weak self] in
+            switch newState {
+            case .validate:
+                self?.checkUpdateButton.setTitle("Validating...", for: .normal)
+                self?.statusLabel.isHidden = true
+            case .upload:
+                self?.checkUpdateButton.setTitle("Uploading...", for: .normal)
+                self?.statusLabel.isHidden = true
+            case .test:
+                self?.checkUpdateButton.setTitle("Testing...", for: .normal)
+                self?.statusLabel.isHidden = true
+            case .confirm:
+                self?.checkUpdateButton.setTitle("Confirming...", for: .normal)
+                self?.statusLabel.isHidden = true
+            case .reset:
+                self?.checkUpdateButton.setTitle("Restarting...", for: .normal)
+                self?.statusLabel.text = "Device is restarting..."
+                self?.statusLabel.textColor = UIColor.primary
+                self?.statusLabel.isHidden = false
+                // Mark that we're expecting a reconnection
+                self?.waitingForReconnectAfterUpdate = true
+            case .success:
+                self?.checkUpdateButton.setTitle("Confirming update...", for: .normal)
+                self?.checkUpdateButton.isEnabled = false
+                self?.statusLabel.text = "Update installed. Confirming..."
+                self?.statusLabel.textColor = UIColor.nordicBlue
+                self?.statusLabel.isHidden = false
+                self?.installButton.isHidden = true
+                self?.updateInfoLabel.isHidden = true
+                // Clear the update info
+                self?.updateInfo = nil
+                self?.hasCheckedForUpdate = false
+                // Update footer
+                self?.updateTableFooter()
+                // Mark that we're waiting for reconnect to confirm the update
+                self?.waitingForReconnectAfterUpdate = true
+            case .none:
+                self?.checkUpdateButton.setTitle("Check for Updates", for: .normal)
+            default:
+                break
+            }
+        }
+    }
+    
+    func upgradeDidFail(inState state: FirmwareUpgradeState, with error: Error) {
+        DispatchQueue.main.async { [weak self] in
+            self?.checkUpdateButton.setTitle("Check for Updates", for: .normal)
+            self?.statusLabel.text = "Update failed: \(error.localizedDescription)"
+            self?.statusLabel.textColor = UIColor.nordicRed
+            self?.statusLabel.isHidden = false
+            self?.installButton.isEnabled = true
+        }
+    }
+    
+    func upgradeDidCancel(state: FirmwareUpgradeState) {
+        DispatchQueue.main.async { [weak self] in
+            self?.checkUpdateButton.setTitle("Check for Updates", for: .normal)
+            self?.statusLabel.text = "Update cancelled"
+            self?.statusLabel.textColor = .orange
+            self?.statusLabel.isHidden = false
+            self?.installButton.isEnabled = true
+        }
+    }
+    
+    func uploadProgressDidChange(bytesSent: Int, imageSize: Int, timestamp: Date) {
+        DispatchQueue.main.async { [weak self] in
+            let progress = Float(bytesSent) / Float(imageSize)
+            self?.checkUpdateButton.setTitle(String(format: "Uploading: %.0f%%", progress * 100), for: .normal)
+        }
+    }
+}
+
+extension Optional where Wrapped == String {
+    var isNilOrEmpty: Bool {
+        return self?.isEmpty ?? true
+    }
+}

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iOSMcuManagerLibrary (1.7.1):
+  - iOSMcuManagerLibrary (1.9.3):
     - SwiftCBOR (= 0.4.7)
     - ZIPFoundation (= 0.9.19)
   - SwiftCBOR (0.4.7)
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSMcuManagerLibrary: 77ab81e59d7f4711b803db3d9475fac70fffc838
+  iOSMcuManagerLibrary: 2ea8e8fe35226619efe44e64765eece75769ed83
   SwiftCBOR: 465775bed0e8bac7bfb8160bcf7b95d7f75971e4
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
 PODFILE CHECKSUM: f2511a9cba22bb3fd31be0da56fd26af29146341
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		BD5A286220CB44B00061F0EE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD5A286020CB44B00061F0EE /* LaunchScreen.storyboard */; };
 		E7F00904AD78FC61457F0B06 /* Pods_nRF_Connect_Device_Manager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C75D2DC863EB4235DE2F466B /* Pods_nRF_Connect_Device_Manager.framework */; };
 		F07D73AC2AE9AE3A00ED6B9A /* StringConvertibles.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07D73AB2AE9AE3A00ED6B9A /* StringConvertibles.swift */; };
+		52ABCDEF210B0EB6000E110E /* NRFViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52ABCDEE210B0EB6000E110E /* NRFViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -69,6 +70,7 @@
 		C75D2DC863EB4235DE2F466B /* Pods_nRF_Connect_Device_Manager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_nRF_Connect_Device_Manager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9EB68FC3504F79AE1891044 /* Pods-nRF Connect Device Manager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nRF Connect Device Manager.debug.xcconfig"; path = "Target Support Files/Pods-nRF Connect Device Manager/Pods-nRF Connect Device Manager.debug.xcconfig"; sourceTree = "<group>"; };
 		F07D73AB2AE9AE3A00ED6B9A /* StringConvertibles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringConvertibles.swift; sourceTree = "<group>"; };
+		52ABCDEE210B0EB6000E110E /* NRFViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NRFViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +119,7 @@
 			children = (
 				526270A2210B8E5E00FC17D4 /* Widgets */,
 				524DCFCF210B0EB6000E110D /* BaseViewController.swift */,
+				52ABCDEE210B0EB6000E110E /* NRFViewController.swift */,
 				524DCFD3210B1C17000E110D /* DeviceController.swift */,
 				526270A3210B8E8000FC17D4 /* ImageController.swift */,
 				5215762E2125B59400C21B0C /* FilesController.swift */,
@@ -336,13 +339,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-nRF Connect Device Manager/Pods-nRF Connect Device Manager-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-nRF Connect Device Manager/Pods-nRF Connect Device Manager-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -377,6 +376,7 @@
 				523C05B32423DA3C0007E563 /* RootViewController.swift in Sources */,
 				5266273724ACA7F4008F528C /* IntroViewController.swift in Sources */,
 				524DCFD0210B0EB6000E110D /* BaseViewController.swift in Sources */,
+				52ABCDEF210B0EB6000E110E /* NRFViewController.swift in Sources */,
 				521576312126CC8F00C21B0C /* FileUploadViewController.swift in Sources */,
 				5274C2622796CEC40043D7CA /* SettingsViewController.swift in Sources */,
 			);

--- a/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
@@ -36,7 +36,9 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
         previousUpdateNotificationSequenceNumber = nil
         log(msg: "Discovering services...", atLevel: .verbose)
         peripheral.delegate = self
-        peripheral.discoverServices([McuMgrBleTransportConstant.SMP_SERVICE])
+        // Discover all services first - this helps trigger pairing if MDS requires it
+        // We'll filter for the specific services we need in the delegate callback
+        peripheral.discoverServices(nil)
     }
     
     public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {

--- a/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
@@ -26,21 +26,58 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
             ?? "none"
         log(msg: "Services discovered: \(s)", atLevel: .verbose)
         
+        // Check if MDS service is present (might require pairing)
+        let hasMDS = peripheral.services?.contains { $0.uuid.uuidString == "54220000-F6A5-4007-A371-722F4EBD8436" } ?? false
+        if !hasMDS {
+            log(msg: "MDS service not found - it may require pairing/bonding", atLevel: .info)
+        }
+        
         // Get peripheral's services.
         guard let services = peripheral.services else {
             connectionLock.open(McuMgrBleTransportError.missingService)
             return
         }
+        
+        var smpServiceFound = false
+        
         // Find the service matching the SMP service UUID.
         for service in services {
             if service.uuid == McuMgrBleTransportConstant.SMP_SERVICE {
-                log(msg: "Discovering characteristics...", atLevel: .verbose)
+                log(msg: "Discovering SMP characteristics...", atLevel: .verbose)
                 peripheral.discoverCharacteristics([McuMgrBleTransportConstant.SMP_CHARACTERISTIC],
                                                    for: service)
-                return
+                smpServiceFound = true
+            } else if service.uuid.uuidString == "54220000-F6A5-4007-A371-722F4EBD8436" {
+                // MDS Service - discover its characteristics for Memfault functionality
+                log(msg: "Discovering MDS characteristics...", atLevel: .verbose)
+                log(msg: "Note: MDS access may trigger pairing/PIN entry dialog", atLevel: .info)
+                discoveredMDSService = service
+                let mdsCharacteristics = [
+                    CBUUID(string: "54220001-F6A5-4007-A371-722F4EBD8436"), // Supported Features
+                    CBUUID(string: "54220002-F6A5-4007-A371-722F4EBD8436"), // Device Identifier
+                    CBUUID(string: "54220003-F6A5-4007-A371-722F4EBD8436"), // Data URI
+                    CBUUID(string: "54220004-F6A5-4007-A371-722F4EBD8436"), // Authorization (contains project key!)
+                    CBUUID(string: "54220005-F6A5-4007-A371-722F4EBD8436")  // Data Export
+                ]
+                peripheral.discoverCharacteristics(mdsCharacteristics, for: service)
+            } else if service.uuid.uuidString == "180A" {
+                // DIS Service - discover its characteristics for device information
+                log(msg: "Discovering DIS characteristics...", atLevel: .verbose)
+                discoveredDISService = service
+                let disCharacteristics = [
+                    CBUUID(string: "2A29"), // Manufacturer Name
+                    CBUUID(string: "2A24"), // Model Number
+                    CBUUID(string: "2A27"), // Hardware Revision
+                    CBUUID(string: "2A26"), // Firmware Revision
+                    CBUUID(string: "2A28")  // Software Revision
+                ]
+                peripheral.discoverCharacteristics(disCharacteristics, for: service)
             }
         }
-        connectionLock.open(McuMgrBleTransportError.missingService)
+        
+        if !smpServiceFound {
+            connectionLock.open(McuMgrBleTransportError.missingService)
+        }
     }
     
     public func peripheral(_ peripheral: CBPeripheral,
@@ -48,7 +85,14 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
                            error: Error?) {
         // Check for error.
         guard error == nil else {
-            connectionLock.open(error)
+            log(msg: "Error discovering characteristics for \(service.uuid): \(error!)", atLevel: .error)
+            // Check if this is an authentication error for MDS
+            if service.uuid.uuidString == "54220000-F6A5-4007-A371-722F4EBD8436" {
+                log(msg: "MDS characteristic discovery failed - pairing may be required", atLevel: .warning)
+            }
+            if service.uuid == McuMgrBleTransportConstant.SMP_SERVICE {
+                connectionLock.open(error)
+            }
             return
         }
         
@@ -60,28 +104,105 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
         
         // Get service's characteristics.
         guard let characteristics = service.characteristics else {
-            connectionLock.open(McuMgrBleTransportError.missingCharacteristic)
+            if service.uuid == McuMgrBleTransportConstant.SMP_SERVICE {
+                connectionLock.open(McuMgrBleTransportError.missingCharacteristic)
+            }
             return
         }
-        // Find the characteristic matching the SMP characteristic UUID.
-        for characteristic in characteristics {
-            if characteristic.uuid == McuMgrBleTransportConstant.SMP_CHARACTERISTIC {
-                // Set the characteristic notification if available.
-                if characteristic.properties.contains(.notify) {
-                    log(msg: "Enabling notifications...", atLevel: .verbose)
-                    peripheral.setNotifyValue(true, for: characteristic)
-                } else {
-                    connectionLock.open(McuMgrBleTransportError.missingNotifyProperty)
+        
+        if service.uuid == McuMgrBleTransportConstant.SMP_SERVICE {
+            // Find the characteristic matching the SMP characteristic UUID.
+            for characteristic in characteristics {
+                if characteristic.uuid == McuMgrBleTransportConstant.SMP_CHARACTERISTIC {
+                    // Set the characteristic notification if available.
+                    if characteristic.properties.contains(.notify) {
+                        log(msg: "Enabling notifications...", atLevel: .verbose)
+                        peripheral.setNotifyValue(true, for: characteristic)
+                    } else {
+                        connectionLock.open(McuMgrBleTransportError.missingNotifyProperty)
+                    }
+                    return
                 }
-                return
+            }
+            connectionLock.open(McuMgrBleTransportError.missingCharacteristic)
+        } else if service.uuid.uuidString == "54220000-F6A5-4007-A371-722F4EBD8436" {
+            // MDS Service characteristics discovered
+            log(msg: "MDS characteristics discovered: \(characteristics.count)", atLevel: .info)
+            for (index, char) in characteristics.enumerated() {
+                log(msg: "  MDS Char \(index): \(char.uuid.uuidString) - Properties: \(char.properties)", atLevel: .info)
+            }
+            discoveredMDSCharacteristics = characteristics
+            
+            // Try to read the authorization characteristic - this may trigger pairing
+            if let authChar = characteristics.first(where: { $0.uuid.uuidString == "54220004-F6A5-4007-A371-722F4EBD8436" }) {
+                log(msg: "Reading MDS Authorization - this may trigger pairing dialog", atLevel: .info)
+                peripheral.readValue(for: authChar)
+            }
+            
+            // Enable notifications for data export characteristic
+            if let dataExportChar = characteristics.first(where: { $0.uuid.uuidString == "54220005-F6A5-4007-A371-722F4EBD8436" }) {
+                log(msg: "Found MDS Data Export characteristic. Properties: \(dataExportChar.properties.rawValue)", atLevel: .info)
+                
+                // Check if there's already data available
+                if let existingData = dataExportChar.value, existingData.count > 0 {
+                    log(msg: "*** MDS DATA EXPORT HAS EXISTING DATA ***", atLevel: .info)
+                    log(msg: "Data size: \(existingData.count) bytes", atLevel: .info)
+                    log(msg: "First 10 bytes: \(existingData.prefix(10).map { String(format: "%02x", $0) }.joined(separator: " "))", atLevel: .info)
+                    
+                    // Delay processing to allow MemfaultManager to connect first
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak peripheral] in
+                        guard let peripheral = peripheral else { return }
+                        self.log(msg: "Processing delayed MDS data export", atLevel: .info)
+                        NotificationCenter.default.post(
+                            name: Notification.Name("MDSDataExportNotification"),
+                            object: nil,
+                            userInfo: ["data": existingData, "peripheral": peripheral]
+                        )
+                    }
+                }
+                
+                if dataExportChar.properties.contains(.notify) {
+                    log(msg: "MDS Data Export supports notifications. Enabling...", atLevel: .info)
+                    peripheral.setNotifyValue(true, for: dataExportChar)
+                } else if dataExportChar.properties.contains(.indicate) {
+                    log(msg: "MDS Data Export supports indications. Enabling...", atLevel: .info)
+                    peripheral.setNotifyValue(true, for: dataExportChar)
+                } else {
+                    log(msg: "MDS Data Export characteristic does not support notifications or indications. Properties: \(dataExportChar.properties)", atLevel: .error)
+                }
+            } else {
+                log(msg: "MDS Data Export characteristic not found among \(characteristics.count) characteristics", atLevel: .warning)
+            }
+        } else if service.uuid.uuidString == "180A" {
+            // DIS Service characteristics discovered
+            log(msg: "DIS characteristics discovered: \(characteristics.count)", atLevel: .verbose)
+            discoveredDISCharacteristics = characteristics
+            
+            // Automatically read DIS characteristic values
+            for characteristic in characteristics {
+                peripheral.readValue(for: characteristic)
+                log(msg: "Reading DIS characteristic: \(characteristic.uuid)", atLevel: .verbose)
             }
         }
-        connectionLock.open(McuMgrBleTransportError.missingCharacteristic)
     }
     
     public func peripheral(_ peripheral: CBPeripheral,
                            didUpdateNotificationStateFor characteristic: CBCharacteristic,
                            error: Error?) {
+        // Handle MDS Data Export notification state changes
+        if characteristic.uuid.uuidString == "54220005-F6A5-4007-A371-722F4EBD8436" {
+            if let error = error {
+                log(msg: "ERROR: Failed to enable MDS Data Export notifications: \(error)", atLevel: .error)
+                log(msg: "Error details: \(error.localizedDescription)", atLevel: .error)
+            } else {
+                log(msg: "SUCCESS: MDS Data Export notifications are now \(characteristic.isNotifying ? "ENABLED" : "DISABLED")", atLevel: .info)
+                if characteristic.isNotifying {
+                    log(msg: "Ready to receive MDS diagnostic data chunks", atLevel: .info)
+                }
+            }
+            return
+        }
+        
         guard characteristic.uuid == McuMgrBleTransportConstant.SMP_CHARACTERISTIC else {
             return
         }
@@ -106,6 +227,60 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
     public func peripheral(_ peripheral: CBPeripheral,
                            didUpdateValueFor characteristic: CBCharacteristic,
                            error: Error?) {
+        // Handle DIS characteristic value updates
+        if characteristic.service?.uuid.uuidString == "180A" {
+            if let error = error {
+                log(msg: "Error reading DIS characteristic \(characteristic.uuid): \(error)", atLevel: .warning)
+            } else if let value = characteristic.value {
+                if let stringValue = String(data: value, encoding: .utf8) {
+                    log(msg: "DIS characteristic \(characteristic.uuid) value: \(stringValue)", atLevel: .verbose)
+                }
+                
+                // Post notification for DIS value updates
+                NotificationCenter.default.post(
+                    name: Notification.Name("DISValueUpdated"),
+                    object: nil,
+                    userInfo: [
+                        "uuid": characteristic.uuid.uuidString,
+                        "value": value
+                    ]
+                )
+            }
+            return
+        }
+        
+        // Handle MDS characteristic value updates
+        if characteristic.service?.uuid.uuidString == "54220000-F6A5-4007-A371-722F4EBD8436" {
+            if let error = error {
+                log(msg: "Error reading MDS characteristic \(characteristic.uuid): \(error)", atLevel: .warning)
+                if (error as NSError).code == 5 || (error as NSError).code == 15 {
+                    log(msg: "MDS read failed due to insufficient authentication - pairing required", atLevel: .warning)
+                }
+            } else if let value = characteristic.value {
+                // Handle data export notifications
+                if characteristic.uuid.uuidString == "54220005-F6A5-4007-A371-722F4EBD8436" {
+                    log(msg: "*** MDS DATA EXPORT NOTIFICATION RECEIVED ***", atLevel: .info)
+                    log(msg: "Data size: \(value.count) bytes", atLevel: .info)
+                    log(msg: "Data hex: \(value.map { String(format: "%02x", $0) }.joined())", atLevel: .info)
+                    log(msg: "First 10 bytes: \(value.prefix(10).map { String(format: "%02x", $0) }.joined(separator: " "))", atLevel: .info)
+                    
+                    // Forward the data to MemfaultManager if it's connected
+                    log(msg: "Posting notification to MemfaultManager", atLevel: .info)
+                    NotificationCenter.default.post(
+                        name: Notification.Name("MDSDataExportNotification"),
+                        object: nil,
+                        userInfo: ["data": value, "peripheral": peripheral]
+                    )
+                } else {
+                    log(msg: "MDS characteristic \(characteristic.uuid) read successfully", atLevel: .info)
+                    if let stringValue = String(data: value, encoding: .utf8) {
+                        log(msg: "MDS value: \(stringValue)", atLevel: .verbose)
+                    }
+                }
+            }
+            return
+        }
+        
         guard characteristic.uuid == McuMgrBleTransportConstant.SMP_CHARACTERISTIC else {
             return
         }

--- a/Source/MDS/CBUUID+MDS.swift
+++ b/Source/MDS/CBUUID+MDS.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import CoreBluetooth
+
+extension CBUUID {
+    
+    // MARK: - Memfault Diagnostic Service (MDS)
+    
+    /// Memfault Diagnostic Service UUID
+    static let mdsService = CBUUID(string: "54220000-F6A5-4007-A371-722F4EBD8436")
+    
+    /// Supported Features characteristic UUID (first characteristic)
+    static let mdsSupportedFeatures = CBUUID(string: "54220001-F6A5-4007-A371-722F4EBD8436")
+    
+    /// Device Identifier characteristic UUID (second characteristic)
+    static let mdsDeviceIdentifier = CBUUID(string: "54220002-F6A5-4007-A371-722F4EBD8436")
+    
+    /// Data URI characteristic UUID (third characteristic)
+    static let mdsDataURI = CBUUID(string: "54220003-F6A5-4007-A371-722F4EBD8436")
+    
+    /// Authorization characteristic UUID (fourth characteristic - contains project key!)
+    static let mdsAuthorization = CBUUID(string: "54220004-F6A5-4007-A371-722F4EBD8436")
+    
+    /// Data Export characteristic UUID (fifth characteristic)
+    static let mdsDataExport = CBUUID(string: "54220005-F6A5-4007-A371-722F4EBD8436")
+    
+    // MARK: - Device Information Service (DIS)
+    
+    /// Standard DIS service UUID
+    static let deviceInformationService = CBUUID(string: "180A")
+    
+    /// DIS characteristics
+    static let manufacturerNameString = CBUUID(string: "2A29")
+    static let modelNumberString = CBUUID(string: "2A24")
+    static let serialNumberString = CBUUID(string: "2A25")
+    static let hardwareRevisionString = CBUUID(string: "2A27")
+    static let firmwareRevisionString = CBUUID(string: "2A26")
+    static let softwareRevisionString = CBUUID(string: "2A28")
+}

--- a/Source/MDS/MemfaultChunk.swift
+++ b/Source/MDS/MemfaultChunk.swift
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Status of a Memfault chunk upload
+public enum MemfaultChunkUploadStatus {
+    case ready
+    case uploading
+    case success
+    case error(Error)
+}
+
+/// Represents a chunk of Memfault diagnostic data
+public class MemfaultChunk: Identifiable, Hashable {
+    
+    public let id = UUID()
+    public let sequenceNumber: UInt16
+    public let data: Data
+    public let timestamp: Date
+    public var uploadStatus: MemfaultChunkUploadStatus = .ready
+    
+    public init(sequenceNumber: UInt16, data: Data, timestamp: Date = Date()) {
+        self.sequenceNumber = sequenceNumber
+        self.data = data
+        self.timestamp = timestamp
+    }
+    
+    // MARK: - Hashable
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
+    public static func == (lhs: MemfaultChunk, rhs: MemfaultChunk) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
+    // MARK: - Helpers
+    
+    public var isReadyForUpload: Bool {
+        if case .ready = uploadStatus {
+            return true
+        }
+        return false
+    }
+    
+    public var hasError: Bool {
+        if case .error = uploadStatus {
+            return true
+        }
+        return false
+    }
+}

--- a/Source/MDS/MemfaultDevice.swift
+++ b/Source/MDS/MemfaultDevice.swift
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import CoreBluetooth
+
+/// Represents a Bluetooth device with Memfault MDS capabilities
+public class MemfaultDevice {
+    
+    public let deviceUUID: String
+    public let peripheral: CBPeripheral
+    
+    public var isConnected: Bool = false
+    public var isNotificationEnabled: Bool = false
+    public var isStreamingData: Bool = false
+    public var chunks: [MemfaultChunk] = []
+    
+    // MDS Service characteristics
+    public var mdsService: CBService?
+    internal var deviceIdentifierCharacteristic: CBCharacteristic?
+    internal var dataURICharacteristic: CBCharacteristic?
+    internal var authenticationCharacteristic: CBCharacteristic?
+    public var dataExportCharacteristic: CBCharacteristic?
+    
+    // DIS Service characteristics
+    public var disService: CBService?
+    internal var manufacturerNameCharacteristic: CBCharacteristic?
+    internal var modelNumberCharacteristic: CBCharacteristic?
+    internal var hardwareRevisionCharacteristic: CBCharacteristic?
+    internal var firmwareRevisionCharacteristic: CBCharacteristic?
+    internal var softwareRevisionCharacteristic: CBCharacteristic?
+    
+    // Device info from MDS
+    public var deviceIdentifier: String?
+    public var dataURI: String?
+    public var authenticationData: Data?
+    public var projectKey: String?
+    
+    // Device info from DIS
+    public var manufacturerName: String?
+    public var modelNumber: String?
+    public var hardwareRevision: String?
+    public var firmwareRevision: String?
+    public var softwareRevision: String?
+    
+    public init(peripheral: CBPeripheral) {
+        self.peripheral = peripheral
+        self.deviceUUID = peripheral.identifier.uuidString
+    }
+    
+    // MARK: - Chunk Management
+    
+    public func addChunk(_ chunk: MemfaultChunk) {
+        chunks.append(chunk)
+    }
+    
+    public func removeChunk(_ chunk: MemfaultChunk) {
+        chunks.removeAll { $0.id == chunk.id }
+    }
+    
+    public func clearChunks() {
+        chunks.removeAll()
+    }
+    
+    public var pendingChunks: [MemfaultChunk] {
+        return chunks.filter { $0.isReadyForUpload }
+    }
+    
+    // MARK: - MDS Support
+    
+    public var hasMDSService: Bool {
+        return mdsService != nil
+    }
+    
+    public var hasAllCharacteristics: Bool {
+        return deviceIdentifierCharacteristic != nil &&
+               dataURICharacteristic != nil &&
+               authenticationCharacteristic != nil &&
+               dataExportCharacteristic != nil
+    }
+    
+    // MARK: - Memfault OTA Support
+    
+    /// Derive hardware version for Memfault API from DIS data
+    public var memfaultHardwareVersion: String {
+        // Try to derive from model number or hardware revision
+        if let modelNumber = modelNumber?.lowercased() {
+            // Extract nRF chip type from model number (e.g., "nRF52840_xxAA" -> "nrf52")
+            if modelNumber.contains("nrf52") {
+                return "nrf52"
+            } else if modelNumber.contains("nrf53") {
+                return "nrf53"
+            } else if modelNumber.contains("nrf54") {
+                return "nrf54"
+            } else if modelNumber.contains("nrf91") {
+                return "nrf91"
+            }
+        }
+        
+        if let hardwareRevision = hardwareRevision?.lowercased() {
+            // Try to extract from hardware revision
+            if hardwareRevision.contains("nrf52") {
+                return "nrf52"
+            } else if hardwareRevision.contains("nrf53") {
+                return "nrf53"
+            } else if hardwareRevision.contains("nrf54") {
+                return "nrf54"
+            } else if hardwareRevision.contains("nrf91") {
+                return "nrf91"
+            }
+        }
+        
+        // Default fallback
+        return "nrf53"
+    }
+    
+    /// Derive software type for Memfault API from DIS/MDS data
+    public var memfaultSoftwareType: String {
+        // Try to derive from firmware or software revision
+        if let softwareRevision = softwareRevision?.lowercased() {
+            // Look for common software type indicators
+            if softwareRevision.contains("bootloader") || softwareRevision.contains("mcuboot") {
+                return "bootloader"
+            } else if softwareRevision.contains("application") || softwareRevision.contains("app") {
+                return "application"
+            }
+        }
+        
+        if let firmwareRevision = firmwareRevision?.lowercased() {
+            if firmwareRevision.contains("bootloader") || firmwareRevision.contains("mcuboot") {
+                return "bootloader"
+            } else if firmwareRevision.contains("application") || firmwareRevision.contains("app") {
+                return "application"
+            }
+        }
+        
+        // Default to "main" (common for application firmware)
+        return "main"
+    }
+}

--- a/Source/MDS/MemfaultError.swift
+++ b/Source/MDS/MemfaultError.swift
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Errors specific to Memfault MDS operations
+public enum MemfaultError: LocalizedError {
+    
+    case mdsServiceNotFound
+    case characteristicNotFound(String)
+    case deviceIdentifierReadFailed
+    case dataURIReadFailed
+    case authenticationDataInvalid
+    case chunkDataInvalid
+    case networkError(Error)
+    case deviceNotConnected
+    case notificationSetupFailed
+    case uploadFailed(Error)
+    
+    public var errorDescription: String? {
+        switch self {
+        case .mdsServiceNotFound:
+            return "MDS service not found on device"
+        case .characteristicNotFound(let name):
+            return "MDS characteristic '\(name)' not found"
+        case .deviceIdentifierReadFailed:
+            return "Failed to read device identifier"
+        case .dataURIReadFailed:
+            return "Failed to read data URI"
+        case .authenticationDataInvalid:
+            return "Invalid authentication data"
+        case .chunkDataInvalid:
+            return "Invalid chunk data received"
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        case .deviceNotConnected:
+            return "Device is not connected"
+        case .notificationSetupFailed:
+            return "Failed to setup notifications"
+        case .uploadFailed(let error):
+            return "Upload failed: \(error.localizedDescription)"
+        }
+    }
+    
+    public var failureReason: String? {
+        switch self {
+        case .mdsServiceNotFound:
+            return "The device does not expose the Memfault Diagnostic Service"
+        case .characteristicNotFound:
+            return "Required MDS characteristic is missing"
+        case .deviceIdentifierReadFailed, .dataURIReadFailed:
+            return "Unable to read device configuration"
+        case .authenticationDataInvalid:
+            return "Device authentication failed"
+        case .chunkDataInvalid:
+            return "Corrupted diagnostic data"
+        case .networkError:
+            return "Unable to connect to Memfault servers"
+        case .deviceNotConnected:
+            return "Bluetooth connection lost"
+        case .notificationSetupFailed:
+            return "Unable to receive data from device"
+        case .uploadFailed:
+            return "Data upload to Memfault failed"
+        }
+    }
+    
+    public var recoverySuggestion: String? {
+        switch self {
+        case .mdsServiceNotFound:
+            return "Enable the MDS service in your device firmware"
+        case .characteristicNotFound:
+            return "Update your device firmware to include all MDS characteristics"
+        case .deviceIdentifierReadFailed, .dataURIReadFailed:
+            return "Reconnect to the device and try again"
+        case .authenticationDataInvalid:
+            return "Check device authentication configuration"
+        case .chunkDataInvalid:
+            return "Reset the device and try again"
+        case .networkError:
+            return "Check your internet connection"
+        case .deviceNotConnected:
+            return "Reconnect to the device"
+        case .notificationSetupFailed:
+            return "Disconnect and reconnect to the device"
+        case .uploadFailed:
+            return "Retry the upload or check network connectivity"
+        }
+    }
+}

--- a/Source/MDS/MemfaultManager+Bluetooth.swift
+++ b/Source/MDS/MemfaultManager+Bluetooth.swift
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import CoreBluetooth
+
+// MARK: - CBPeripheralDelegate
+
+extension MemfaultManager: CBPeripheralDelegate {
+    
+    public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard error == nil else {
+            print("MemfaultManager: Error discovering services: \(error!)")
+            onError?(.mdsServiceNotFound)
+            return
+        }
+        
+        guard let services = peripheral.services else {
+            onError?(.mdsServiceNotFound)
+            return
+        }
+        
+        // Look for MDS service
+        if let mdsService = services.first(where: { $0.uuid == .mdsService }) {
+            print("MemfaultManager: Found MDS service")
+            connectedDevice?.mdsService = mdsService
+            
+            // Discover MDS characteristics
+            peripheral.discoverCharacteristics([
+                .mdsSupportedFeatures,
+                .mdsDeviceIdentifier,
+                .mdsDataURI,
+                .mdsAuthorization,
+                .mdsDataExport
+            ], for: mdsService)
+        } else {
+            print("MemfaultManager: MDS service not found")
+        }
+        
+        // Look for DIS service (always useful for device info)
+        if let disService = services.first(where: { $0.uuid == .deviceInformationService }) {
+            print("MemfaultManager: Found DIS service")
+            connectedDevice?.disService = disService
+            
+            // Discover DIS characteristics
+            peripheral.discoverCharacteristics([
+                .manufacturerNameString,
+                .modelNumberString,
+                .hardwareRevisionString,
+                .firmwareRevisionString,
+                .softwareRevisionString
+            ], for: disService)
+        } else {
+            print("MemfaultManager: DIS service not found")
+        }
+        
+        // If neither service is found, consider it an error
+        if connectedDevice?.mdsService == nil && connectedDevice?.disService == nil {
+            onError?(.mdsServiceNotFound)
+        }
+    }
+    
+    public func peripheral(_ peripheral: CBPeripheral, 
+                          didDiscoverCharacteristicsFor service: CBService, 
+                          error: Error?) {
+        guard error == nil else {
+            print("MemfaultManager: Error discovering characteristics: \(error!)")
+            return
+        }
+        
+        guard let device = connectedDevice,
+              let characteristics = service.characteristics else { return }
+        
+        if service.uuid == .mdsService {
+            print("MemfaultManager: Discovered \(characteristics.count) MDS characteristics")
+            
+            // Map MDS characteristics
+            for characteristic in characteristics {
+                switch characteristic.uuid {
+                case .mdsSupportedFeatures:
+                    // We don't need to store this characteristic for now
+                    peripheral.readValue(for: characteristic)
+                    
+                case .mdsDeviceIdentifier:
+                    device.deviceIdentifierCharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                case .mdsDataURI:
+                    device.dataURICharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                case .mdsAuthorization:
+                    device.authenticationCharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                case .mdsDataExport:
+                    device.dataExportCharacteristic = characteristic
+                    // This will be used for notifications
+                    
+                default:
+                    break
+                }
+            }
+            
+            // Check if we have all required MDS characteristics
+            if device.hasAllCharacteristics {
+                print("MemfaultManager: All MDS characteristics found")
+                device.isConnected = true
+                onDeviceConnected?(device)
+            }
+            
+        } else if service.uuid == .deviceInformationService {
+            print("MemfaultManager: Discovered \(characteristics.count) DIS characteristics")
+            
+            // Map DIS characteristics and read their values
+            for characteristic in characteristics {
+                switch characteristic.uuid {
+                case .manufacturerNameString:
+                    device.manufacturerNameCharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                case .modelNumberString:
+                    device.modelNumberCharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                case .hardwareRevisionString:
+                    device.hardwareRevisionCharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                case .firmwareRevisionString:
+                    device.firmwareRevisionCharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                case .softwareRevisionString:
+                    device.softwareRevisionCharacteristic = characteristic
+                    peripheral.readValue(for: characteristic)
+                    
+                default:
+                    break
+                }
+            }
+        }
+    }
+    
+    public func peripheral(_ peripheral: CBPeripheral, 
+                          didUpdateValueFor characteristic: CBCharacteristic, 
+                          error: Error?) {
+        guard error == nil,
+              let device = connectedDevice else {
+            if let error = error {
+                print("MemfaultManager: Error reading characteristic: \(error)")
+            }
+            return
+        }
+        
+        // Handle case where characteristic value is nil or empty
+        guard let data = characteristic.value, !data.isEmpty else {
+            // Special handling for MDS Data Export - empty means no more chunks
+            if characteristic.uuid == .mdsDataExport {
+                print("MemfaultManager: No more chunks available in MDS Data Export")
+            }
+            return
+        }
+        
+        print("MemfaultManager: Received value for characteristic \(characteristic.uuid.uuidString)")
+        if let stringValue = String(data: data, encoding: .utf8) {
+            print("MemfaultManager: String value for \(characteristic.uuid.uuidString): '\(stringValue)'")
+        }
+        
+        // Print hex value for debugging
+        print("MemfaultManager: Hex value: \(data.map { String(format: "%02x", $0) }.joined())")
+        
+        switch characteristic.uuid {
+        // MDS characteristics
+        case .mdsSupportedFeatures:
+            // Just log the supported features
+            if let stringValue = String(data: data, encoding: .utf8) {
+                print("MemfaultManager: Supported features: '\(stringValue)'")
+            }
+            
+        case .mdsDeviceIdentifier:
+            handleDeviceIdentifierUpdate(data, device: device)
+            
+        case .mdsDataURI:
+            handleDataURIUpdate(data, device: device)
+            
+        case .mdsAuthorization:
+            handleAuthenticationUpdate(data, device: device)
+            
+        case .mdsDataExport:
+            handleDataExportUpdate(data, device: device)
+            
+        // DIS characteristics
+        case .manufacturerNameString:
+            handleManufacturerNameUpdate(data, device: device)
+            
+        case .modelNumberString:
+            handleModelNumberUpdate(data, device: device)
+            
+        case .hardwareRevisionString:
+            handleHardwareRevisionUpdate(data, device: device)
+            
+        case .firmwareRevisionString:
+            handleFirmwareRevisionUpdate(data, device: device)
+            
+        case .softwareRevisionString:
+            handleSoftwareRevisionUpdate(data, device: device)
+            
+        default:
+            break
+        }
+    }
+    
+    public func peripheral(_ peripheral: CBPeripheral, 
+                          didUpdateNotificationStateFor characteristic: CBCharacteristic, 
+                          error: Error?) {
+        guard error == nil,
+              let device = connectedDevice else {
+            if let error = error {
+                print("MemfaultManager: Error setting notification state: \(error)")
+                onError?(.notificationSetupFailed)
+            }
+            return
+        }
+        
+        if characteristic.uuid == .mdsDataExport {
+            device.isNotificationEnabled = characteristic.isNotifying
+            device.isStreamingData = characteristic.isNotifying
+            print("MemfaultManager: Data export notifications \(characteristic.isNotifying ? "enabled" : "disabled")")
+        }
+    }
+    
+    // MARK: - Characteristic Update Handlers
+    
+    private func handleDeviceIdentifierUpdate(_ data: Data, device: MemfaultDevice) {
+        guard let identifier = String(data: data, encoding: .utf8) else {
+            onError?(.deviceIdentifierReadFailed)
+            return
+        }
+        
+        device.deviceIdentifier = identifier
+        print("MemfaultManager: Device identifier: '\(identifier)'")
+        
+        // Check if this might contain project key info
+        if identifier.contains("project_key=") {
+            extractProjectKey(from: identifier, device: device)
+        } else if identifier.hasPrefix("Memfault-Project-Key:") {
+            let prefix = "Memfault-Project-Key:"
+            let projectKey = identifier.replacingOccurrences(of: prefix, with: "").trimmingCharacters(in: .whitespaces)
+            if !projectKey.isEmpty {
+                device.projectKey = projectKey
+                print("MemfaultManager: Extracted project key from device ID: \(projectKey)")
+                onDeviceInfoUpdated?(device)
+            }
+        }
+    }
+    
+    private func handleDataURIUpdate(_ data: Data, device: MemfaultDevice) {
+        guard let uri = String(data: data, encoding: .utf8) else {
+            print("MemfaultManager: Failed to parse Data URI from data: \(data.map { String(format: "%02x", $0) }.joined())")
+            onError?(.dataURIReadFailed)
+            return
+        }
+        
+        device.dataURI = uri
+        print("MemfaultManager: Data URI received: '\(uri)'")
+        print("MemfaultManager: Data URI length: \(uri.count) characters")
+        
+        // If URI contains a project key, extract it
+        if uri.contains("project_key=") {
+            print("MemfaultManager: Data URI contains project_key parameter")
+            extractProjectKey(from: uri, device: device)
+        } else {
+            print("MemfaultManager: Data URI does not contain project_key parameter")
+        }
+        
+        // The project key might be in the authentication data or needs to be configured separately
+        // For now, notify that device info is updated
+        onDeviceInfoUpdated?(device)
+    }
+    
+    private func handleAuthenticationUpdate(_ data: Data, device: MemfaultDevice) {
+        device.authenticationData = data
+        print("MemfaultManager: Authentication data received (\(data.count) bytes)")
+        
+        // Extract project key from authentication data
+        if let authString = String(data: data, encoding: .utf8) {
+            print("MemfaultManager: Authentication string: '\(authString)'")
+            
+            // Try to extract project key - it might be in different formats
+            // Format 1: "Memfault-Project-Key:<key>"
+            // Format 2: Just the key itself
+            // Format 3: Part of a URL query parameter
+            
+            let prefix = "Memfault-Project-Key:"
+            if authString.hasPrefix(prefix) {
+                let projectKey = authString.replacingOccurrences(of: prefix, with: "").trimmingCharacters(in: .whitespaces)
+                if !projectKey.isEmpty {
+                    device.projectKey = projectKey
+                    print("MemfaultManager: Extracted project key from header format: \(projectKey)")
+                    print("MemfaultManager: Calling onDeviceInfoUpdated callback")
+                    onDeviceInfoUpdated?(device)
+                }
+            } else if authString.contains("project_key=") {
+                // Try to extract from URL format
+                extractProjectKey(from: authString, device: device)
+            } else if !authString.isEmpty && !authString.contains("http") && !authString.contains("/") {
+                // Might be just the key itself
+                let trimmedKey = authString.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmedKey.count >= 20 { // Project keys are typically long
+                    device.projectKey = trimmedKey
+                    print("MemfaultManager: Using authentication value as project key: \(trimmedKey)")
+                    onDeviceInfoUpdated?(device)
+                }
+            }
+        }
+    }
+    
+    internal func handleDataExportUpdate(_ data: Data, device: MemfaultDevice) {
+        print("MemfaultManager: Processing data export update: \(data.count) bytes")
+        print("MemfaultManager: Data hex: \(data.map { String(format: "%02x", $0) }.joined())")
+        
+        guard let chunk = parseChunkData(data) else {
+            print("MemfaultManager: Failed to parse chunk data")
+            onError?(.chunkDataInvalid)
+            return
+        }
+        
+        print("MemfaultManager: Received chunk \(chunk.sequenceNumber) (\(chunk.data.count) bytes)")
+        device.addChunk(chunk)
+        onChunkReceived?(chunk)
+        
+        // Auto-upload chunks if we have a project key
+        if device.projectKey != nil && device.pendingChunks.count >= 1 {
+            print("MemfaultManager: Auto-uploading \(device.pendingChunks.count) chunks")
+            uploadPendingChunks()
+        }
+        
+        // No acknowledgment needed - MDS uses continuous notifications
+        // The device will send all chunks via notifications once streaming is enabled
+    }
+    
+    private func extractProjectKey(from uri: String, device: MemfaultDevice) {
+        // Parse the URI to extract project key
+        // Expected format: https://api.memfault.com/api/v0/chunks?project_key=<key>
+        
+        guard let url = URL(string: uri),
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            print("MemfaultManager: Could not parse data URI")
+            return
+        }
+        
+        if let projectKeyItem = queryItems.first(where: { $0.name == "project_key" }),
+           let projectKey = projectKeyItem.value {
+            device.projectKey = projectKey
+            print("MemfaultManager: Extracted project key: \(projectKey)")
+            // Notify that device info has been updated (including project key)
+            onDeviceInfoUpdated?(device)
+        }
+    }
+    
+    // MARK: - DIS Characteristic Update Handlers
+    
+    internal func handleManufacturerNameUpdate(_ data: Data, device: MemfaultDevice) {
+        guard let manufacturerName = String(data: data, encoding: .utf8) else {
+            print("MemfaultManager: Failed to parse manufacturer name")
+            return
+        }
+        
+        device.manufacturerName = manufacturerName
+        print("MemfaultManager: Manufacturer name: \(manufacturerName)")
+        // Don't call onDeviceInfoUpdated here - wait until all values are read
+    }
+    
+    internal func handleModelNumberUpdate(_ data: Data, device: MemfaultDevice) {
+        guard let modelNumber = String(data: data, encoding: .utf8) else {
+            print("MemfaultManager: Failed to parse model number")
+            return
+        }
+        
+        device.modelNumber = modelNumber
+        print("MemfaultManager: Model number: \(modelNumber)")
+        // Don't call onDeviceInfoUpdated here - wait until all values are read
+    }
+    
+    internal func handleHardwareRevisionUpdate(_ data: Data, device: MemfaultDevice) {
+        guard let hardwareRevision = String(data: data, encoding: .utf8) else {
+            print("MemfaultManager: Failed to parse hardware revision")
+            return
+        }
+        
+        device.hardwareRevision = hardwareRevision
+        print("MemfaultManager: Hardware revision: \(hardwareRevision)")
+        // Don't call onDeviceInfoUpdated here - wait until all values are read
+    }
+    
+    internal func handleFirmwareRevisionUpdate(_ data: Data, device: MemfaultDevice) {
+        guard let firmwareRevision = String(data: data, encoding: .utf8) else {
+            print("MemfaultManager: Failed to parse firmware revision")
+            return
+        }
+        
+        device.firmwareRevision = firmwareRevision
+        print("MemfaultManager: Firmware revision: \(firmwareRevision)")
+        // Don't call onDeviceInfoUpdated here - wait until all values are read
+    }
+    
+    internal func handleSoftwareRevisionUpdate(_ data: Data, device: MemfaultDevice) {
+        guard let softwareRevision = String(data: data, encoding: .utf8) else {
+            print("MemfaultManager: Failed to parse software revision")
+            return
+        }
+        
+        device.softwareRevision = softwareRevision
+        print("MemfaultManager: Software revision: \(softwareRevision)")
+        // Don't call onDeviceInfoUpdated here - wait until all values are read
+    }
+}

--- a/Source/MDS/MemfaultManager.swift
+++ b/Source/MDS/MemfaultManager.swift
@@ -1,0 +1,659 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import CoreBluetooth
+
+/// Main manager for Memfault MDS operations
+public class MemfaultManager: NSObject {
+    
+    // MARK: - Properties
+    
+    public var connectedDevice: MemfaultDevice?
+    public var isScanning: Bool = false
+    public var uploadProgress: Double = 0.0
+    
+    private var centralManager: CBCentralManager?
+    private var currentPeripheral: CBPeripheral?
+    
+    // Callbacks
+    public var onDeviceConnected: ((MemfaultDevice) -> Void)?
+    public var onDeviceDisconnected: ((MemfaultDevice) -> Void)?
+    public var onDeviceInfoUpdated: ((MemfaultDevice) -> Void)?
+    public var onChunkReceived: ((MemfaultChunk) -> Void)?
+    public var onChunkUploaded: ((MemfaultChunk) -> Void)?
+    public var onError: ((MemfaultError) -> Void)?
+    
+    // MARK: - Initialization
+    
+    public override init() {
+        super.init()
+        
+        // Listen for MDS data export notifications from the transport
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMDSDataExportNotification(_:)),
+            name: Notification.Name("MDSDataExportNotification"),
+            object: nil
+        )
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Connect to a device that already has a BLE connection through McuMgrBleTransport
+    public func connectToDevice(peripheral: CBPeripheral, transport: McuMgrBleTransport? = nil) {
+        print("MemfaultManager: Connecting to device \(peripheral.identifier)")
+        print("MemfaultManager: Current peripheral state: \(peripheral.state)")
+        print("MemfaultManager: Current peripheral delegate: \(String(describing: peripheral.delegate))")
+        
+        currentPeripheral = peripheral
+        
+        let device = MemfaultDevice(peripheral: peripheral)
+        connectedDevice = device
+        
+        // Check if peripheral is already connected
+        if peripheral.state == .connected {
+            print("MemfaultManager: Peripheral already connected, checking for services")
+            
+            // If we have a transport, try to get MDS/DIS services from it
+            if let transport = transport {
+                print("MemfaultManager: Checking transport for discovered MDS/DIS services")
+                checkTransportServices(transport, device: device)
+            } else if let services = peripheral.services {
+                print("MemfaultManager: Found \(services.count) existing services: \(services.map { $0.uuid.uuidString })")
+                handleExistingServices(services, peripheral: peripheral)
+            } else {
+                print("MemfaultManager: No transport provided and no existing services found")
+                onError?(.mdsServiceNotFound)
+            }
+        } else {
+            print("MemfaultManager: Peripheral not connected (state: \(peripheral.state))")
+            onError?(.mdsServiceNotFound)
+        }
+    }
+    
+    private func handleExistingServices(_ services: [CBService], peripheral: CBPeripheral) {
+        // Process already discovered services
+        for service in services {
+            if service.uuid == .mdsService {
+                print("MemfaultManager: Found existing MDS service")
+                connectedDevice?.mdsService = service
+                
+                // Check if characteristics are already discovered
+                if let characteristics = service.characteristics {
+                    print("MemfaultManager: MDS service has \(characteristics.count) existing characteristics")
+                    handleMDSCharacteristics(characteristics, service: service, peripheral: peripheral)
+                } else {
+                    print("MemfaultManager: Need to discover MDS characteristics")
+                    // We'd need to discover characteristics but can't without delegate
+                }
+            } else if service.uuid == .deviceInformationService {
+                print("MemfaultManager: Found existing DIS service")
+                connectedDevice?.disService = service
+                
+                // Check if characteristics are already discovered
+                if let characteristics = service.characteristics {
+                    print("MemfaultManager: DIS service has \(characteristics.count) existing characteristics")
+                    handleDISCharacteristics(characteristics, service: service, peripheral: peripheral)
+                } else {
+                    print("MemfaultManager: Need to discover DIS characteristics")
+                    // We'd need to discover characteristics but can't without delegate
+                }
+            }
+        }
+        
+        // Check if we found what we need
+        let hasMDS = connectedDevice?.mdsService != nil
+        let hasDIS = connectedDevice?.disService != nil
+        
+        print("MemfaultManager: Service discovery summary - MDS: \(hasMDS), DIS: \(hasDIS)")
+        
+        if hasMDS {
+            connectedDevice?.isConnected = true
+            onDeviceConnected?(connectedDevice!)
+        } else if hasDIS {
+            // DIS without MDS is still useful
+            connectedDevice?.isConnected = true
+            onDeviceConnected?(connectedDevice!)
+        } else {
+            onError?(.mdsServiceNotFound)
+        }
+    }
+    
+    private func checkTransportServices(_ transport: McuMgrBleTransport, device: MemfaultDevice) {
+        print("MemfaultManager: Checking transport for MDS and DIS services")
+        print("MemfaultManager: Transport state: \(transport.state)")
+        
+        // If transport is not connected yet, wait a moment and retry
+        if transport.state != .connected {
+            print("MemfaultManager: Transport not fully connected, waiting...")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.checkTransportServices(transport, device: device)
+            }
+            return
+        }
+        
+        // Check for MDS service
+        if let mdsService = transport.mdsService {
+            print("MemfaultManager: Found MDS service from transport")
+            device.mdsService = mdsService
+            
+            // Get MDS characteristics from transport
+            let mdsCharacteristics = transport.mdsCharacteristics
+            print("MemfaultManager: Found \(mdsCharacteristics.count) MDS characteristics")
+            handleMDSCharacteristics(mdsCharacteristics, service: mdsService, peripheral: device.peripheral)
+        } else {
+            print("MemfaultManager: No MDS service found in transport")
+        }
+        
+        // Check for DIS service
+        if let disService = transport.disService {
+            print("MemfaultManager: Found DIS service from transport")
+            device.disService = disService
+            
+            // Get DIS characteristics from transport
+            let disCharacteristics = transport.disCharacteristics
+            print("MemfaultManager: Found \(disCharacteristics.count) DIS characteristics")
+            handleDISCharacteristics(disCharacteristics, service: disService, peripheral: device.peripheral)
+        } else {
+            print("MemfaultManager: No DIS service found in transport")
+        }
+        
+        // Check if we found what we need
+        let hasMDS = device.mdsService != nil
+        let hasDIS = device.disService != nil
+        
+        print("MemfaultManager: Service check summary - MDS: \(hasMDS), DIS: \(hasDIS)")
+        
+        if hasMDS || hasDIS {
+            device.isConnected = true
+            onDeviceConnected?(device)
+            
+            // Read values from DIS characteristics if available
+            if hasDIS {
+                readDISCharacteristics(device: device)
+            }
+            
+            // Read values from MDS characteristics if available
+            if hasMDS {
+                readMDSCharacteristics(device: device)
+            }
+        } else {
+            print("MemfaultManager: No MDS or DIS services found")
+            onError?(.mdsServiceNotFound)
+        }
+    }
+    
+    private func readDISCharacteristics(device: MemfaultDevice) {
+        guard let peripheral = currentPeripheral else { return }
+        
+        print("MemfaultManager: Reading DIS characteristics")
+        
+        // Since we can't be the delegate, we'll read the values synchronously if they're already cached
+        if let char = device.manufacturerNameCharacteristic, let value = char.value {
+            handleManufacturerNameUpdate(value, device: device)
+        } else if let char = device.manufacturerNameCharacteristic {
+            print("MemfaultManager: Requesting read of manufacturer name")
+            peripheral.readValue(for: char)
+        }
+        
+        if let char = device.modelNumberCharacteristic, let value = char.value {
+            handleModelNumberUpdate(value, device: device)
+        } else if let char = device.modelNumberCharacteristic {
+            print("MemfaultManager: Requesting read of model number")
+            peripheral.readValue(for: char)
+        }
+        
+        if let char = device.hardwareRevisionCharacteristic, let value = char.value {
+            handleHardwareRevisionUpdate(value, device: device)
+        } else if let char = device.hardwareRevisionCharacteristic {
+            print("MemfaultManager: Requesting read of hardware revision")
+            peripheral.readValue(for: char)
+        }
+        
+        if let char = device.firmwareRevisionCharacteristic, let value = char.value {
+            handleFirmwareRevisionUpdate(value, device: device)
+        } else if let char = device.firmwareRevisionCharacteristic {
+            print("MemfaultManager: Requesting read of firmware revision")
+            peripheral.readValue(for: char)
+        }
+        
+        if let char = device.softwareRevisionCharacteristic, let value = char.value {
+            handleSoftwareRevisionUpdate(value, device: device)
+        } else if let char = device.softwareRevisionCharacteristic {
+            print("MemfaultManager: Requesting read of software revision")
+            peripheral.readValue(for: char)
+        }
+        
+        // Since we're not the delegate, we'll set a timer to check for values later
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.checkDISValues(device: device)
+        }
+    }
+    
+    private func readMDSCharacteristics(device: MemfaultDevice) {
+        guard let peripheral = currentPeripheral else { return }
+        
+        print("MemfaultManager: Reading MDS characteristics")
+        
+        // Read Device Identifier
+        if let char = device.deviceIdentifierCharacteristic {
+            print("MemfaultManager: Requesting read of MDS device identifier")
+            if let value = char.value {
+                print("MemfaultManager: Device ID value already available")
+                if let identifier = String(data: value, encoding: .utf8) {
+                    device.deviceIdentifier = identifier
+                    print("MemfaultManager: Device identifier from cache: '\(identifier)'")
+                }
+            } else {
+                peripheral.readValue(for: char)
+            }
+        }
+        
+        // Read Data URI
+        if let char = device.dataURICharacteristic {
+            print("MemfaultManager: Requesting read of MDS data URI")
+            if let value = char.value {
+                print("MemfaultManager: Data URI value already available")
+                if let uri = String(data: value, encoding: .utf8) {
+                    device.dataURI = uri
+                    print("MemfaultManager: Data URI from cache: '\(uri)'")
+                }
+            } else {
+                peripheral.readValue(for: char)
+            }
+        }
+        
+        // Read Authorization data (contains project key!)
+        if let char = device.authenticationCharacteristic {
+            print("MemfaultManager: Requesting read of MDS authorization (contains project key)")
+            // Check if value is already available
+            if let value = char.value {
+                print("MemfaultManager: Authorization value already available, processing it")
+                // Process the authorization value directly
+                if let authString = String(data: value, encoding: .utf8) {
+                    print("MemfaultManager: Processing cached authorization value: '\(authString)'")
+                    let prefix = "Memfault-Project-Key:"
+                    if authString.hasPrefix(prefix) {
+                        let projectKey = authString.replacingOccurrences(of: prefix, with: "").trimmingCharacters(in: .whitespaces)
+                        if !projectKey.isEmpty {
+                            device.projectKey = projectKey
+                            print("MemfaultManager: Extracted project key: \(projectKey)")
+                            onDeviceInfoUpdated?(device)
+                        }
+                    }
+                }
+            } else {
+                print("MemfaultManager: No cached value, requesting read")
+                peripheral.readValue(for: char)
+            }
+        }
+        
+        // Don't read data export - that's for notifications only
+    }
+    
+    private func checkDISValues(device: MemfaultDevice) {
+        print("MemfaultManager: Checking DIS values after delay")
+        var hasUpdates = false
+        
+        if let char = device.manufacturerNameCharacteristic, let value = char.value {
+            handleManufacturerNameUpdate(value, device: device)
+            hasUpdates = true
+        }
+        
+        if let char = device.modelNumberCharacteristic, let value = char.value {
+            handleModelNumberUpdate(value, device: device)
+            hasUpdates = true
+        }
+        
+        if let char = device.hardwareRevisionCharacteristic, let value = char.value {
+            handleHardwareRevisionUpdate(value, device: device)
+            hasUpdates = true
+        }
+        
+        if let char = device.firmwareRevisionCharacteristic, let value = char.value {
+            handleFirmwareRevisionUpdate(value, device: device)
+            hasUpdates = true
+        }
+        
+        if let char = device.softwareRevisionCharacteristic, let value = char.value {
+            handleSoftwareRevisionUpdate(value, device: device)
+            hasUpdates = true
+        }
+        
+        if hasUpdates {
+            onDeviceInfoUpdated?(device)
+        }
+    }
+    
+    private func requestServiceDiscovery(peripheral: CBPeripheral) {
+        // Since we can't set ourselves as delegate without breaking the existing connection,
+        // we need to work with what's already available or find another approach
+        print("MemfaultManager: Cannot discover services without taking over delegate")
+        print("MemfaultManager: Services should be discovered through transport layer")
+        
+        // For now, indicate that services are not available
+        // In a real implementation, we might need to coordinate with the transport
+        onError?(.mdsServiceNotFound)
+    }
+    
+    private func handleMDSCharacteristics(_ characteristics: [CBCharacteristic], service: CBService, peripheral: CBPeripheral) {
+        guard let device = connectedDevice else { return }
+        
+        print("MemfaultManager: Processing \(characteristics.count) MDS characteristics")
+        
+        for characteristic in characteristics {
+            switch characteristic.uuid {
+            case .mdsDeviceIdentifier:
+                device.deviceIdentifierCharacteristic = characteristic
+                print("MemfaultManager: Found MDS Device Identifier characteristic")
+                
+            case .mdsDataURI:
+                device.dataURICharacteristic = characteristic
+                print("MemfaultManager: Found MDS Data URI characteristic")
+                
+            case .mdsAuthorization:
+                device.authenticationCharacteristic = characteristic
+                print("MemfaultManager: Found MDS Authorization characteristic (contains project key!)")
+                
+            case .mdsDataExport:
+                device.dataExportCharacteristic = characteristic
+                print("MemfaultManager: Found MDS Data Export characteristic")
+                
+            default:
+                print("MemfaultManager: Found unknown MDS characteristic: \(characteristic.uuid)")
+            }
+        }
+    }
+    
+    private func handleDISCharacteristics(_ characteristics: [CBCharacteristic], service: CBService, peripheral: CBPeripheral) {
+        guard let device = connectedDevice else { return }
+        
+        print("MemfaultManager: Processing \(characteristics.count) DIS characteristics")
+        
+        for characteristic in characteristics {
+            switch characteristic.uuid {
+            case .manufacturerNameString:
+                device.manufacturerNameCharacteristic = characteristic
+                print("MemfaultManager: Found DIS Manufacturer Name characteristic")
+                
+            case .modelNumberString:
+                device.modelNumberCharacteristic = characteristic
+                print("MemfaultManager: Found DIS Model Number characteristic")
+                
+            case .hardwareRevisionString:
+                device.hardwareRevisionCharacteristic = characteristic
+                print("MemfaultManager: Found DIS Hardware Revision characteristic")
+                
+            case .firmwareRevisionString:
+                device.firmwareRevisionCharacteristic = characteristic
+                print("MemfaultManager: Found DIS Firmware Revision characteristic")
+                
+            case .softwareRevisionString:
+                device.softwareRevisionCharacteristic = characteristic
+                print("MemfaultManager: Found DIS Software Revision characteristic")
+                
+            default:
+                print("MemfaultManager: Found unknown DIS characteristic: \(characteristic.uuid)")
+            }
+        }
+    }
+    
+    /// Disconnect from the current device
+    public func disconnect() {
+        guard let device = connectedDevice else { return }
+        
+        print("MemfaultManager: Disconnecting from device")
+        
+        // Stop notifications
+        stopDataExportNotifications()
+        
+        // Clear device
+        connectedDevice = nil
+        currentPeripheral = nil
+        
+        onDeviceDisconnected?(device)
+    }
+    
+    /// Upload pending chunks to Memfault
+    public func uploadPendingChunks() {
+        guard let device = connectedDevice else { return }
+        
+        let pendingChunks = device.pendingChunks
+        guard !pendingChunks.isEmpty else {
+            print("MemfaultManager: No pending chunks to upload")
+            return
+        }
+        
+        print("MemfaultManager: Uploading \(pendingChunks.count) chunks")
+        uploadChunks(pendingChunks)
+    }
+    
+    /// Start streaming diagnostic data from the device
+    public func startDataStreaming() {
+        guard let device = connectedDevice,
+              let dataExportChar = device.dataExportCharacteristic,
+              let peripheral = currentPeripheral else {
+            onError?(.deviceNotConnected)
+            return
+        }
+        
+        print("MemfaultManager: Starting data streaming")
+        
+        // Enable streaming by writing 0x01 to the Data Export characteristic
+        let enableStreamingCommand = Data([0x01])
+        
+        // Check characteristic properties to determine write type
+        if dataExportChar.properties.contains(.write) {
+            peripheral.writeValue(enableStreamingCommand, for: dataExportChar, type: .withResponse)
+            print("MemfaultManager: Sent enable streaming command (0x01) with response")
+        } else if dataExportChar.properties.contains(.writeWithoutResponse) {
+            peripheral.writeValue(enableStreamingCommand, for: dataExportChar, type: .withoutResponse)
+            print("MemfaultManager: Sent enable streaming command (0x01) without response")
+        } else {
+            print("MemfaultManager: ERROR - Data Export characteristic doesn't support any write type!")
+        }
+        
+        device.isStreamingData = true
+        onDeviceInfoUpdated?(device)
+    }
+    
+    /// Stop streaming diagnostic data
+    public func stopDataStreaming() {
+        guard let device = connectedDevice,
+              let dataExportChar = device.dataExportCharacteristic,
+              let peripheral = currentPeripheral else { return }
+        
+        print("MemfaultManager: Stopping data streaming")
+        
+        // Disable streaming by writing 0x00 to the Data Export characteristic
+        let disableStreamingCommand = Data([0x00])
+        peripheral.writeValue(disableStreamingCommand, for: dataExportChar, type: .withoutResponse)
+        print("MemfaultManager: Sent disable streaming command (0x00)")
+        
+        device.isStreamingData = false
+        onDeviceInfoUpdated?(device)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func stopDataExportNotifications() {
+        guard let device = connectedDevice,
+              let characteristic = device.dataExportCharacteristic else { return }
+        
+        currentPeripheral?.setNotifyValue(false, for: characteristic)
+        device.isStreamingData = false
+    }
+    
+    private func uploadChunks(_ chunks: [MemfaultChunk]) {
+        guard let device = connectedDevice,
+              let projectKey = device.projectKey else {
+            print("MemfaultManager: Missing project key for upload")
+            return
+        }
+        
+        uploadProgress = 0.0
+        let totalChunks = chunks.count
+        var completedChunks = 0
+        
+        for chunk in chunks {
+            chunk.uploadStatus = .uploading
+            
+            uploadChunkToMemfault(chunk, projectKey: projectKey) { [weak self] result in
+                DispatchQueue.main.async {
+                    completedChunks += 1
+                    self?.uploadProgress = Double(completedChunks) / Double(totalChunks)
+                    
+                    switch result {
+                    case .success:
+                        chunk.uploadStatus = .success
+                        device.removeChunk(chunk)
+                        print("MemfaultManager: Chunk \(chunk.sequenceNumber) uploaded successfully")
+                        self?.onChunkUploaded?(chunk)
+                        
+                    case .failure(let error):
+                        chunk.uploadStatus = .error(error)
+                        print("MemfaultManager: Failed to upload chunk \(chunk.sequenceNumber): \(error)")
+                        self?.onError?(.uploadFailed(error))
+                    }
+                }
+            }
+        }
+    }
+    
+    private func uploadChunkToMemfault(_ chunk: MemfaultChunk, 
+                                     projectKey: String, 
+                                     completion: @escaping (Result<Void, Error>) -> Void) {
+        // Check if we should use the device's data URI instead
+        var urlString = "https://api.memfault.com/api/v0/chunks"
+        if let device = connectedDevice, let dataURI = device.dataURI, !dataURI.isEmpty {
+            print("MemfaultManager: Using device-provided data URI: \(dataURI)")
+            urlString = dataURI
+        } else {
+            print("MemfaultManager: Using default Memfault chunks URL: \(urlString)")
+        }
+        
+        guard let url = URL(string: urlString) else {
+            print("MemfaultManager: Invalid URL: \(urlString)")
+            completion(.failure(MemfaultError.networkError(NSError(domain: "InvalidURL", code: 0))))
+            return
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(projectKey, forHTTPHeaderField: "Memfault-Project-Key")
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = chunk.data
+        
+        print("MemfaultManager: HTTP Request Details:")
+        print("  - URL: \(url.absoluteString)")
+        print("  - Method: POST")
+        print("  - Headers:")
+        print("    - Memfault-Project-Key: \(projectKey)")
+        print("    - Content-Type: application/octet-stream")
+        print("  - Body size: \(chunk.data.count) bytes")
+        print("  - Body hex (first 20 bytes): \(chunk.data.prefix(20).map { String(format: "%02x", $0) }.joined(separator: " "))")
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                print("MemfaultManager: Network error: \(error)")
+                completion(.failure(error))
+                return
+            }
+            
+            if let httpResponse = response as? HTTPURLResponse {
+                print("MemfaultManager: HTTP Response:")
+                print("  - Status Code: \(httpResponse.statusCode)")
+                print("  - Headers: \(httpResponse.allHeaderFields)")
+                
+                if let responseData = data {
+                    print("  - Response body size: \(responseData.count) bytes")
+                    if let responseString = String(data: responseData, encoding: .utf8) {
+                        print("  - Response body: \(responseString)")
+                    }
+                }
+                
+                if httpResponse.statusCode == 200 || httpResponse.statusCode == 202 {
+                    print("MemfaultManager: Chunk uploaded successfully!")
+                    completion(.success(()))
+                } else {
+                    print("MemfaultManager: Upload failed with status \(httpResponse.statusCode)")
+                    let errorMessage = "HTTP \(httpResponse.statusCode)"
+                    if let responseData = data, let responseString = String(data: responseData, encoding: .utf8) {
+                        print("MemfaultManager: Error response: \(responseString)")
+                    }
+                    let error = NSError(domain: "MemfaultAPI", 
+                                      code: httpResponse.statusCode, 
+                                      userInfo: [NSLocalizedDescriptionKey: errorMessage])
+                    completion(.failure(error))
+                }
+            }
+        }.resume()
+    }
+    
+    internal func parseChunkData(_ data: Data) -> MemfaultChunk? {
+        // MDS chunk packet format per spec:
+        // Byte 0: Sequence counter (bits 0-4) and reserved bits (5-7)
+        // Byte 1+: Chunk payload
+        
+        guard data.count > 1 else { 
+            print("MemfaultManager: Chunk data too small (size: \(data.count))")
+            return nil 
+        }
+        
+        // Extract sequence number from first byte (bits 0-4)
+        let sequenceByte = data[0]
+        let sequenceNumber = UInt16(sequenceByte & 0x1F) // Mask to get bits 0-4
+        
+        // Extract the actual chunk payload (skip the sequence byte)
+        let chunkPayload = data.subdata(in: 1..<data.count)
+        
+        print("MemfaultManager: Parsed MDS packet - sequence: \(sequenceNumber), payload size: \(chunkPayload.count)")
+        print("MemfaultManager: Sequence byte: 0x\(String(format: "%02x", sequenceByte))")
+        
+        // Return the payload without the MDS packet header
+        return MemfaultChunk(sequenceNumber: sequenceNumber, data: chunkPayload)
+    }
+    
+    // MARK: - Notification Handlers
+    
+    @objc private func handleMDSDataExportNotification(_ notification: Notification) {
+        print("MemfaultManager: *** NOTIFICATION RECEIVED IN MEMFAULT MANAGER ***")
+        
+        guard let userInfo = notification.userInfo else {
+            print("MemfaultManager: No userInfo in notification")
+            return
+        }
+        
+        guard let data = userInfo["data"] as? Data else {
+            print("MemfaultManager: No data in notification userInfo")
+            return
+        }
+        
+        guard let peripheral = userInfo["peripheral"] as? CBPeripheral else {
+            print("MemfaultManager: No peripheral in notification userInfo")
+            return
+        }
+        
+        guard let device = connectedDevice else {
+            print("MemfaultManager: No connected device")
+            return
+        }
+        
+        guard device.peripheral.identifier == peripheral.identifier else {
+            print("MemfaultManager: Peripheral mismatch - received: \(peripheral.identifier), expected: \(device.peripheral.identifier)")
+            return
+        }
+        
+        print("MemfaultManager: Processing MDS data export: \(data.count) bytes")
+        print("MemfaultManager: First 10 bytes: \(data.prefix(10).map { String(format: "%02x", $0) }.joined(separator: " "))")
+        handleDataExportUpdate(data, device: device)
+    }
+}

--- a/Source/MDS/MemfaultOTAManager.swift
+++ b/Source/MDS/MemfaultOTAManager.swift
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Manager class for handling Memfault OTA update checks and downloads
+public class MemfaultOTAManager {
+    
+    // MARK: - Types
+    
+    public struct UpdateInfo {
+        public let version: String
+        public let downloadUrl: URL
+        public let releaseNotes: String?
+    }
+    
+    public enum OTAError: LocalizedError {
+        case invalidProjectKey
+        case networkError(Error)
+        case invalidResponse(String?)
+        case noUpdateAvailable
+        
+        public var errorDescription: String? {
+            switch self {
+            case .invalidProjectKey:
+                return "Invalid or missing Memfault project key"
+            case .networkError(let error):
+                return "Network error: \(error.localizedDescription)"
+            case .invalidResponse(let details):
+                if let details = details, !details.isEmpty {
+                    return "Memfault API Error: \(details)"
+                } else {
+                    return "Invalid response from Memfault API"
+                }
+            case .noUpdateAvailable:
+                return "No update available"
+            }
+        }
+    }
+    
+    // MARK: - Properties
+    
+    private let projectKey: String
+    private let hardwareVersion: String
+    private let softwareType: String
+    private var deviceSerial: String?
+    private let session = URLSession.shared
+    
+    private var updateCache: [String: UpdateInfo] = [:]
+    private var checkingVersions: Set<String> = []
+    
+    // MARK: - Initialization
+    
+    public init(projectKey: String, hardwareVersion: String = "nrf53", softwareType: String = "main", deviceSerial: String? = nil) {
+        self.projectKey = projectKey
+        self.hardwareVersion = hardwareVersion
+        self.softwareType = softwareType
+        self.deviceSerial = deviceSerial
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Check for available firmware updates
+    public func checkForUpdate(currentVersion: String, completion: @escaping (Result<UpdateInfo?, OTAError>) -> Void) {
+        guard !projectKey.isEmpty else {
+            DispatchQueue.main.async {
+                completion(.failure(.invalidProjectKey))
+            }
+            return
+        }
+        
+        // Prevent duplicate checks for the same version
+        guard !checkingVersions.contains(currentVersion) else {
+            print("MemfaultOTAManager: Already checking for updates for version \(currentVersion)")
+            return
+        }
+        checkingVersions.insert(currentVersion)
+        
+        // Check cache first
+        let cacheKey = "\(hardwareVersion)-\(softwareType)-\(currentVersion)"
+        if let cachedUpdate = updateCache[cacheKey] {
+            checkingVersions.remove(currentVersion)
+            DispatchQueue.main.async {
+                completion(.success(cachedUpdate))
+            }
+            return
+        }
+        
+        var urlComponents = URLComponents(string: "https://api.memfault.com/api/v0/releases/latest")!
+        urlComponents.queryItems = [
+            URLQueryItem(name: "hardware_version", value: hardwareVersion),
+            URLQueryItem(name: "software_type", value: softwareType),
+            URLQueryItem(name: "current_version", value: currentVersion)
+        ]
+        
+        if let serial = deviceSerial {
+            urlComponents.queryItems?.append(URLQueryItem(name: "device_serial", value: serial))
+        }
+        
+        var request = URLRequest(url: urlComponents.url!)
+        request.setValue(projectKey, forHTTPHeaderField: "Memfault-Project-Key")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        session.dataTask(with: request) { [weak self] data, response, error in
+            defer {
+                self?.checkingVersions.remove(currentVersion)
+            }
+            
+            if let error = error {
+                DispatchQueue.main.async {
+                    completion(.failure(.networkError(error)))
+                }
+                return
+            }
+            
+            guard let httpResponse = response as? HTTPURLResponse else {
+                DispatchQueue.main.async {
+                    completion(.failure(.invalidResponse("No HTTP response")))
+                }
+                return
+            }
+            
+            // Log response for debugging
+            print("MemfaultOTAManager: HTTP Status: \(httpResponse.statusCode)")
+            
+            guard let data = data else {
+                DispatchQueue.main.async {
+                    completion(.failure(.invalidResponse("No data received")))
+                }
+                return
+            }
+            
+            // Parse JSON response
+            do {
+                if httpResponse.statusCode == 204 {
+                    // No update available
+                    self?.updateCache[cacheKey] = nil
+                    DispatchQueue.main.async {
+                        completion(.success(nil))
+                    }
+                    return
+                }
+                
+                guard httpResponse.statusCode == 200 else {
+                    let errorBody = String(data: data, encoding: .utf8)
+                    print("MemfaultOTAManager: Error response: \(errorBody ?? "none")")
+                    
+                    // Try to parse error response for better error messages
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let error = json["error"] as? [String: Any],
+                       let message = error["message"] as? String {
+                        DispatchQueue.main.async {
+                            completion(.failure(.invalidResponse(message)))
+                        }
+                    } else {
+                        DispatchQueue.main.async {
+                            completion(.failure(.invalidResponse(errorBody)))
+                        }
+                    }
+                    return
+                }
+                
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                
+                // Get version from top level
+                guard let version = json?["version"] as? String else {
+                    DispatchQueue.main.async {
+                        completion(.failure(.invalidResponse("Invalid JSON structure - missing 'version'")))
+                    }
+                    return
+                }
+                
+                // Get artifacts array
+                guard let artifacts = json?["artifacts"] as? [[String: Any]] else {
+                    DispatchQueue.main.async {
+                        completion(.failure(.invalidResponse("Invalid JSON structure - missing 'artifacts' array")))
+                    }
+                    return
+                }
+                
+                // Get first artifact with URL
+                guard let artifact = artifacts.first,
+                      let urlString = artifact["url"] as? String,
+                      let url = URL(string: urlString) else {
+                    DispatchQueue.main.async {
+                        completion(.failure(.invalidResponse("Invalid JSON structure - missing artifact URL")))
+                    }
+                    return
+                }
+                
+                // Get release notes from 'notes' field
+                let releaseNotes = json?["notes"] as? String
+                let updateInfo = UpdateInfo(version: version, downloadUrl: url, releaseNotes: releaseNotes)
+                
+                // Cache the result
+                self?.updateCache[cacheKey] = updateInfo
+                
+                DispatchQueue.main.async {
+                    completion(.success(updateInfo))
+                }
+                
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(.invalidResponse("JSON parsing error: \(error)")))
+                }
+            }
+        }.resume()
+    }
+    
+    /// Download firmware from the provided URL
+    public func downloadFirmware(from url: URL, progress: @escaping (Double) -> Void, completion: @escaping (Result<Data, Error>) -> Void) {
+        var observation: NSKeyValueObservation?
+        
+        let task = session.downloadTask(with: url) { localURL, response, error in
+            observation?.invalidate()
+            
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let localURL = localURL else {
+                completion(.failure(OTAError.invalidResponse("No file downloaded")))
+                return
+            }
+            
+            do {
+                let data = try Data(contentsOf: localURL)
+                completion(.success(data))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+        
+        // Observe download progress
+        observation = task.observe(\.countOfBytesReceived) { task, _ in
+            let totalBytes = task.countOfBytesExpectedToReceive
+            if totalBytes > 0 {
+                let downloadProgress = Double(task.countOfBytesReceived) / Double(totalBytes)
+                DispatchQueue.main.async {
+                    progress(downloadProgress)
+                }
+            }
+        }
+        
+        task.resume()
+    }
+}

--- a/Source/Utils/FirmwareFormatDetector.swift
+++ b/Source/Utils/FirmwareFormatDetector.swift
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Utility to detect firmware file formats based on content
+public enum FirmwareFormatDetector {
+    
+    public enum FirmwareFormat: String {
+        case zip = "zip"
+        case hex = "hex"
+        case bin = "bin"
+        case suit = "suit"
+        
+        public var displayName: String {
+            switch self {
+            case .zip: return "ZIP Archive"
+            case .hex: return "Intel HEX"
+            case .bin: return "Binary"
+            case .suit: return "SUIT Envelope"
+            }
+        }
+    }
+    
+    /// Detect firmware format from data
+    public static func detectFormat(from data: Data) -> FirmwareFormat {
+        guard !data.isEmpty else { return .bin }
+        
+        // Check ZIP magic number: PK\x03\x04
+        if data.count >= 4 && data[0] == 0x50 && data[1] == 0x4B && data[2] == 0x03 && data[3] == 0x04 {
+            return .zip
+        }
+        
+        // Check Intel HEX format (starts with ':')
+        if data.first == 0x3A {
+            return .hex
+        }
+        
+        // Check SUIT envelope (CBOR format, typically starts with specific bytes)
+        // SUIT envelopes often start with 0xD8 (CBOR tag)
+        if data.first == 0xD8 {
+            return .suit
+        }
+        
+        // Default to binary
+        return .bin
+    }
+    
+    /// Save firmware data to temporary file with appropriate extension
+    public static func saveFirmwareToTemporaryFile(_ data: Data, format: FirmwareFormat? = nil) throws -> URL {
+        let detectedFormat = format ?? detectFormat(from: data)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("firmware_\(UUID().uuidString).\(detectedFormat.rawValue)")
+        try data.write(to: tempURL)
+        return tempURL
+    }
+}


### PR DESCRIPTION
This PR integrates the nRF Memfault SDK (MDS - Memfault Diagnostic Service) and adds support for nRF Cloud OTA updates.

Key changes:
- Added MemfaultManager for MDS service communication and chunk streaming
- Added MemfaultOTAManager for checking and downloading firmware updates
- Added MemfaultDevice and MemfaultChunk data models
- Added MemfaultError for comprehensive error handling
- Integrated MDS service discovery into McuMgrBleTransport
- Added nRF Cloud tab in example app with device info, OTA updates, and MDS streaming
- Added CLAUDE.md documentation for the codebase

The implementation supports:
- Automatic MDS service and characteristic discovery
- Project key extraction from device
- Chunk streaming with sequence tracking
- Auto-upload of chunks to Memfault cloud
- OTA update checking and downloading
- Comprehensive device information display