### PR TITLE
Attempted Support for Group-Specific Errors in FileSystemManager

### DIFF
--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -398,7 +398,11 @@ public class FileSystemManager: McuManager {
         }
         // Check for an error return code.
         if let error = response.getError() {
-            self.cancelTransfer(error: error)
+            guard let groupError = response.groupRC?.groupError() else {
+                self.cancelTransfer(error: error)
+                return
+            }
+            self.cancelTransfer(error: groupError)
             return
         }
         // Get the offset from the response.


### PR DESCRIPTION
Some errors from the Filesystem Group, such as errors when writing to a file, etc. need to be read correctly via their Group RC code, instead of defaulting to the standard McuMgr Error Group. Otherwise, the cause of a failure might not be understood correctly. Like, "Error Code 8" means "Busy, Try Later" in Standard but is actually "Write Failed" for Filesystem.

"Attempted" because I could replicate the error last night, but lost the code in a Git mishap, and now I can't replicate it.