### PR TITLE
Patched McuMgrBleTransport's initial MTU Value

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -161,14 +161,14 @@ public class McuMgrBleTransport: NSObject {
         self.operationQueue = OperationQueue()
         self.operationQueue.qualityOfService = .userInitiated
         self.operationQueue.maxConcurrentOperationCount = 1
-
         super.init()
 
         self.centralManager.delegate = self
         self.peripheral = peripheral
+        let peripheralWriteValueLength = max(McuManager.ValidMTURange.lowerBound, peripheral?.maximumWriteValueLength(for: .withoutResponse) ?? 0)
         self.mtu = peripheral == nil
-                ? McuManager.getDefaultMtu(scheme: getScheme())
-                : min(peripheral!.maximumWriteValueLength(for: .withoutResponse), McuManager.getDefaultMtu(scheme: getScheme()))
+            ? McuManager.getDefaultMtu(scheme: getScheme())
+            : min(peripheralWriteValueLength, McuManager.getDefaultMtu(scheme: getScheme()))
     }
     
     public var name: String? {
@@ -177,10 +177,11 @@ public class McuMgrBleTransport: NSObject {
     
     public private(set) var identifier: UUID
 
+    // MARK: notifyPeripheralDelegate
+    
     private func notifyPeripheralDelegate() {
-        if let peripheral = self.peripheral {
-            delegate?.peripheral(peripheral, didChangeStateTo: state)
-        }
+        guard let delegate, let peripheral else { return }
+        delegate.peripheral(peripheral, didChangeStateTo: state)
     }
 }
 


### PR DESCRIPTION
This should be rare, in the sense that peripheral.maximumWriteLength(for: .withoutResponse) should provide a good number that's correct. But we have feedback, like here https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/361 that we suspect, a value of '20' must be wrong. And anyway, any operation could never go through with a value of 20 because it's smaller than the header size, so nothing is going to work. So we're basically patching it to always be the smallest value it can be. And also yes, modified a bit more of code since it was around.