### PR TITLE
Preliminary (as in, we'd be surprised if there are no issues) support for Pipelining in FileSystemManager

### DIFF
--- a/Example/Example/View Controllers/Manager/FileUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileUploadViewController.swift
@@ -48,7 +48,8 @@ class FileUploadViewController: UIViewController, McuMgrViewController {
         actionSelect.isEnabled = false
         status.textColor = .primary
         status.text = "UPLOADING..."
-        _ = fsManager.upload(name: destination.text!, data: fileData!, delegate: self)
+        _ = fsManager.upload(name: destination.text!, data: fileData!,
+                             delegate: self)
     }
     
     @IBAction func pause(_ sender: UIButton) {
@@ -134,7 +135,7 @@ extension FileUploadViewController: FileUploadDelegate {
             speedInKiloBytesPerSecond = Double(fileSize - initialBytes) / msSinceUploadBegan
         }
         
-        status.text = "UPLOADING... (\(String(format: "%.2f", speedInKiloBytesPerSecond))) kB/s)"
+        status.text = "UPLOADING... (\(String(format: "%.2f", speedInKiloBytesPerSecond)) kB/s)"
         progress.setProgress(Float(bytesSent) / Float(fileSize), animated: true)
     }
     

--- a/Source/Managers/ImageManager.swift
+++ b/Source/Managers/ImageManager.swift
@@ -515,8 +515,8 @@ public class ImageManager: McuManager {
     }
     
     private func sendNext(from offset: UInt64) {
-        let imageData: Data! = self.uploadImages?[uploadIndex].data
-        let imageSlot: Int! = self.uploadImages?[uploadIndex].image
+        let imageData: Data! = uploadImages?[uploadIndex].data
+        let imageSlot: Int! = uploadImages?[uploadIndex].image
         upload(data: imageData, image: imageSlot, offset: offset,
                alignment: uploadConfiguration.byteAlignment,
                callback: uploadCallback)


### PR DESCRIPTION
So, it was possible to enable pipelining via FirmwareUpgradeConfiguration 'configuration' argument. But it was not implemented, so no speed improvement or changing in behaviour would occur. Now, it is enabled internally via the same McuMgrUploadPipeline, shared with ImageManager and SuitManager. Preliminary tests show it working as expected, but FileSystemManager is complicated to test due to the small external flash storage availability. But we're here to solve issues.