### PR TITLE
Dynamic bluetooth UUIDs

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -62,12 +62,12 @@ final class BaseViewController: UITabBarController {
     
     var peripheral: DiscoveredPeripheral! {
         didSet {
-            let bleTransport = McuMgrBleTransport(peripheral.basePeripheral)
+            let bleTransport = McuMgrBleTransport(peripheral.basePeripheral, DefaultMcuMgrUuidConfig())
             bleTransport.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
             bleTransport.delegate = self
             transport = bleTransport
             // Independent transport for BaseViewController operations.
-            privateTransport = McuMgrBleTransport(peripheral.basePeripheral)
+            privateTransport = McuMgrBleTransport(peripheral.basePeripheral, DefaultMcuMgrUuidConfig())
         }
     }
     

--- a/Example/Example/View Controllers/Scanner/ScannerViewController.swift
+++ b/Example/Example/View Controllers/Scanner/ScannerViewController.swift
@@ -187,7 +187,7 @@ class ScannerViewController: UITableViewController, CBCentralManagerDelegate, UI
     private func startScanner() {
         activityIndicator.startAnimating()
         let hidService: CBUUID! = CBUUID(string: "1812")
-        let connectedPeripherals = centralManager.retrieveConnectedPeripherals(withServices: [McuMgrBleTransportConstant.SMP_SERVICE, hidService])
+        let connectedPeripherals = centralManager.retrieveConnectedPeripherals(withServices: [DefaultMcuMgrUuidConfig().serviceUuid, hidService])
         for peripheral in connectedPeripherals {
             var advertisementData = [String: Any]()
             advertisementData[CBAdvertisementDataLocalNameKey] = peripheral.name ?? ""
@@ -231,7 +231,7 @@ class ScannerViewController: UITableViewController, CBCentralManagerDelegate, UI
     /// - returns: True, if the peripheral matches the filter,
     ///   false otherwise.
     private func matchesFilters(_ discoveredPeripheral: DiscoveredPeripheral) -> Bool {
-        if filterByUuid && discoveredPeripheral.advertisedServices?.contains(McuMgrBleTransportConstant.SMP_SERVICE) != true {
+        if filterByUuid && discoveredPeripheral.advertisedServices?.contains(DefaultMcuMgrUuidConfig().serviceUuid) != true {
             return false
         }
         if filterByRssi && discoveredPeripheral.highestRSSI.decimalValue < -50 {

--- a/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
@@ -36,7 +36,7 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
         previousUpdateNotificationSequenceNumber = nil
         log(msg: "Discovering services...", atLevel: .verbose)
         peripheral.delegate = self
-        peripheral.discoverServices([McuMgrBleTransportConstant.SMP_SERVICE])
+        peripheral.discoverServices([uuidConfig.serviceUuid])
     }
     
     public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {

--- a/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
+++ b/Source/Bluetooth/McuMgrBleTransport+CBPeripheralDelegate.swift
@@ -33,9 +33,9 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
         }
         // Find the service matching the SMP service UUID.
         for service in services {
-            if service.uuid == McuMgrBleTransportConstant.SMP_SERVICE {
+            if service.uuid == uuidConfig.serviceUuid {
                 log(msg: "Discovering characteristics...", atLevel: .verbose)
-                peripheral.discoverCharacteristics([McuMgrBleTransportConstant.SMP_CHARACTERISTIC],
+                peripheral.discoverCharacteristics([uuidConfig.characteristicUuid],
                                                    for: service)
                 return
             }
@@ -65,7 +65,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
         }
         // Find the characteristic matching the SMP characteristic UUID.
         for characteristic in characteristics {
-            if characteristic.uuid == McuMgrBleTransportConstant.SMP_CHARACTERISTIC {
+            if characteristic.uuid == uuidConfig.characteristicUuid {
                 // Set the characteristic notification if available.
                 if characteristic.properties.contains(.notify) {
                     log(msg: "Enabling notifications...", atLevel: .verbose)
@@ -82,7 +82,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
     public func peripheral(_ peripheral: CBPeripheral,
                            didUpdateNotificationStateFor characteristic: CBCharacteristic,
                            error: Error?) {
-        guard characteristic.uuid == McuMgrBleTransportConstant.SMP_CHARACTERISTIC else {
+        guard characteristic.uuid == uuidConfig.characteristicUuid else {
             return
         }
         // Check for error.
@@ -107,7 +107,7 @@ extension McuMgrBleTransport: CBPeripheralDelegate {
     public func peripheral(_ peripheral: CBPeripheral,
                            didUpdateValueFor characteristic: CBCharacteristic,
                            error: Error?) {
-        guard characteristic.uuid == McuMgrBleTransportConstant.SMP_CHARACTERISTIC else {
+        guard characteristic.uuid == uuidConfig.characteristicUuid else {
             return
         }
         

--- a/Source/Bluetooth/UuidConfig.swift
+++ b/Source/Bluetooth/UuidConfig.swift
@@ -1,0 +1,17 @@
+import CoreBluetooth
+
+/// Allows providing a custom set of UUIDs for the McuMgr BLE Transport.
+protocol UuidConfig {
+    
+    /// The SMP service UUID.
+    var serviceUuid: CBUUID { get }
+    
+    /// The SMP characteristic UUID.
+    var characteristicUuid: CBUUID { get }
+}
+
+/// The default UUID configuration for the McuMgr.
+class DefaultMcuMgrUuidConfig : UuidConfig {
+    let serviceUuid: CBUUID = CBUUID(string: "8D53DC1D-1DB7-4CD3-868B-8A527460AA84")
+    let characteristicUuid: CBUUID = CBUUID(string: "DA2E7828-FBCE-4E01-AE9E-261174997C48")
+}

--- a/Source/Bluetooth/UuidConfig.swift
+++ b/Source/Bluetooth/UuidConfig.swift
@@ -1,7 +1,7 @@
 import CoreBluetooth
 
 /// Allows providing a custom set of UUIDs for the McuMgr BLE Transport.
-protocol UuidConfig {
+public protocol UuidConfig {
     
     /// The SMP service UUID.
     var serviceUuid: CBUUID { get }
@@ -11,7 +11,8 @@ protocol UuidConfig {
 }
 
 /// The default UUID configuration for the McuMgr.
-class DefaultMcuMgrUuidConfig : UuidConfig {
-    let serviceUuid: CBUUID = CBUUID(string: "8D53DC1D-1DB7-4CD3-868B-8A527460AA84")
-    let characteristicUuid: CBUUID = CBUUID(string: "DA2E7828-FBCE-4E01-AE9E-261174997C48")
+public struct DefaultMcuMgrUuidConfig : UuidConfig {
+    public init() {}
+    public let serviceUuid: CBUUID = CBUUID(string: "8D53DC1D-1DB7-4CD3-868B-8A527460AA84")
+    public let characteristicUuid: CBUUID = CBUUID(string: "DA2E7828-FBCE-4E01-AE9E-261174997C48")
 }


### PR DESCRIPTION
# Added
- Created `UuidConfig` class to open up the Bluetooth transport to dynamic UUIDs. This mimics the [Android](https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/blob/main/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/UuidConfig.java) implementation.
- Created a `DefaultMcuMgrUuidConfig` that replaces the constants `McuMgrBleTransportConstant.SMP_SERVICE` and `McuMgrBleTransportConstant.SMP_CHARACTERISTIC`.