### PR TITLE
Added "Mode 7" to BootloaderInfoResponse.Mode Enum

### DIFF
--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -864,6 +864,7 @@ public final class BootloaderInfoResponse: McuMgrResponse {
         case directXIPNoRevert = 4
         case directXIPWithRevert = 5
         case RAMLoader = 6
+        case firmwareLoader = 7
         
         /**
          Intended for use cases where it's not important to know what kind of DirectXIP
@@ -892,6 +893,8 @@ public final class BootloaderInfoResponse: McuMgrResponse {
                 return "Direct-XIP with revert"
             case .RAMLoader:
                 return "RAM Loader"
+            case .firmwareLoader:
+                return "Firmware Loader"
             }
         }
         


### PR DESCRIPTION
No, not that [mode seven](https://www.youtube.com/watch?v=kwAjG2dj5ZM&t=386s). It's a different mode seven, but very important for us regardless.