### PR TITLE
Initial NCS Bare Metal Firmware Update Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,13 @@ do {
 
 This is our new, improved, all-conquering API. You create a `McuMgrPackage`, and you give it to the `FirmwareUpgradeManager`. [There's no Step Three](https://www.youtube.com/watch?v=A0QK0JfHzhg&pp). This API supports:
 
-- [x] .bin file(s) (Single-Core nRF52xxx) MCUboot Application Update
+- [x] .bin file(s)
+  - [x] (Single-Core nRF52xxx) MCUboot Application Update
+  - [x] (Bare Metal nRF54xx) MCUboot Update
 - [x] .suit file(s) (~~Canonical nRF54xx)~~ SUIT Update
 - [x] .zip file(s)
   - [x] DirectXIP (nRF52840) MCUboot Upgrade
   - [x] Multi-Image (Application Core, Network Core nRF5340) MCUboot Update
-  - [x] Multi-Image (nRF54xx) MCUboot Update
   - [x] Multi-Image (Polling - Resources Required nRF54xx) SUIT Update
 - [ ] Custom Uploads
 

--- a/Source/McuMgrResponse.swift
+++ b/Source/McuMgrResponse.swift
@@ -875,6 +875,13 @@ public final class BootloaderInfoResponse: McuMgrResponse {
             return self == .directXIPNoRevert || self == .directXIPWithRevert
         }
         
+        /**
+         - Returns: `true` if the Bootloader represents Nordic Bare Metal SDK-based firmware.
+         */
+        public var isBareMetal: Bool {
+            return self == .firmwareLoader
+        }
+        
         public var description: String {
             switch self {
             case .unknown:


### PR DESCRIPTION
This is not an automatic update. Reset into Firmware Loader mode is needed. Then going back, reconnecting to the device, and sending the application .bin file.