### PR TITLE
Fix: Better Feedback for crashes when calling APIs from Background Threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ McuManager is organized by functionality into command groups. In _mcumgr-ios_, c
 * **`ShellManager`**: Send McuMgr Shell commands to the device.
 * **`SuitManager`**: Send SUIT (Software Update for Internet of Things)-specific commands to the device. This applies to devices running SUIT as their bootloader.
 
+> [!CAUTION]
+> **Always make your API calls from the Main Thread**. For DFU, FileSystem, etc. Unless calls from background threads are explicitly mentioned as allowed. This requirement has its roots in programming invariants written into the library since its *Inception*.
+> 
+> **We will crash if we catch you to alert you of the issue as soon as possible.**
+
 # Firmware Upgrade
 
 Firmware upgrade is generally a four step process performed using commands from the `image` and `default` commands groups: `upload`, `test`, `reset`, and `confirm`.
@@ -115,9 +120,6 @@ This library provides `FirmwareUpgradeManager` as a convenience for upgrading th
 ## FirmwareUpgradeManager
 
 `FirmwareUpgradeManager` provides an easy way to perform firmware upgrades on a device. A `FirmwareUpgradeManager` must be initialized with an `McuMgrTransport` which defines the transport scheme and device. Once initialized, `FirmwareUpgradeManager` can perform one firmware upgrade at a time. Firmware upgrades are started using the `start(package: McuMgrPackage)` function and can be paused, resumed, and canceled using `pause()`, `resume()`, and `cancel()` respectively.
-
-> [!CAUTION]
-> **Always** make your start/pause/cancel DFU API calls from the Main Thread.
 
 > [!TIP]
 > You may reuse a `FirmwareUpgradeManager` / `McuMgrTransport` combo for multiple operations. But it is recommended to make a new pair for each operation. For example, for each DFU attempt. Nevertheless, we will provide support (and fixes) for issues stemming from keeping the same pair for multiple operations.

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -99,6 +99,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
             objc_sync_exit(self)
         }
         
+        self.imageManager.verifyOnMainThread()
         guard state == .none else {
             log(msg: "Firmware upgrade is already in progress", atLevel: .warning)
             return
@@ -113,7 +114,6 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         
         log(msg: "Upgrade started with \(images.count) image(s) using '\(configuration.upgradeMode)' mode",
             atLevel: .application)
-        dispatchPrecondition(condition: .onQueue(.main))
         delegate?.upgradeDidStart(controller: self)
         
         requestMcuMgrParameters()

--- a/Source/Managers/FileSystemManager.swift
+++ b/Source/Managers/FileSystemManager.swift
@@ -85,8 +85,12 @@ public class FileSystemManager: McuManager {
                        delegate uploadDelegate: FileUploadDelegate? = nil,
                        callback: @escaping McuMgrCallback<McuMgrFsUploadResponse>) {
         objc_sync_enter(self)
-        if transferState != .uploading {
+        if transferState == .none {
             transferState = .uploading
+        } else {
+            log(msg: "A file transfer is already in progress.", atLevel: .warning)
+            objc_sync_exit(self)
+            return
         }
         objc_sync_exit(self)
         
@@ -156,6 +160,8 @@ public class FileSystemManager: McuManager {
         }
         objc_sync_exit(self)
         
+        verifyOnMainThread()
+        
         // Set download delegate.
         downloadDelegate = delegate
         
@@ -210,6 +216,8 @@ public class FileSystemManager: McuManager {
             return false
         }
         objc_sync_exit(self)
+        
+        verifyOnMainThread()
         
         // Set upload delegate.
         uploadDelegate = delegate

--- a/Source/Managers/SuitManager.swift
+++ b/Source/Managers/SuitManager.swift
@@ -207,6 +207,8 @@ public class SuitManager: McuManager {
     // MARK: upload(_:delegate:)
     
     public func upload(_ images: [ImageManager.Image], using configuration: FirmwareUpgradeConfiguration, delegate: SuitManagerDelegate?) {
+        verifyOnMainThread()
+        
         // Sort Images so Envelope is at index zero.
         uploadImages = images.sorted(by: { l, _ in
             l.content == .suitEnvelope

--- a/Source/McuManager.swift
+++ b/Source/McuManager.swift
@@ -23,7 +23,7 @@ extension McuSequenceNumber {
     }
 }
 
-open class McuManager : NSObject {
+open class McuManager: NSObject {
     class var TAG: McuMgrLogCategory { .default }
     
     //**************************************************************************
@@ -79,7 +79,23 @@ open class McuManager : NSObject {
         self.transport = transport
     }
     
-    // MARK: - Send
+    // MARK: verifyOnMainThread
+    
+    /**
+     A big part of this library, if not 95% of it, was written before Nordic inheritance.
+     
+     And, the code assumes, in many places, it's being run from the Main Thread. So this
+     is why this (maybe annoying) function is called to crash on you. To tell you about it
+     - don't make actionable calls from background threads.
+     */
+    internal func verifyOnMainThread() {
+        guard Thread.isMainThread else {
+            fatalError("Call from @MainActor / DispatchQueue.main. Don't call from background threads.")
+        }
+        dispatchPrecondition(condition: .onQueue(.main))
+    }
+    
+    // MARK: send
     
     public func send<T: McuMgrResponse, R: RawRepresentable>(op: McuMgrOperation, commandId: R, payload: [String:CBOR]?,
                                                              timeout: Int = DEFAULT_SEND_TIMEOUT_SECONDS,


### PR DESCRIPTION
This Boeing 747 of a library is very analog. We've been extending it, granted, but to keep it "within the 747 family" we're trying to match it as much as possible. An all-encompassing rewrite is not in the cards, currently. But the structure of the library expects to always be called externally from the Main Thread, so, in the past we've thrown errors / crashed on purpose to alert developers not to do this. It is also in bright red "Caution" in the README to do this. Anyway, we've changed the structure of the code around so the stack trace makes it a lot more explicit as to what the underlying issue is.

This is in reference to GitHub Issue https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/383