### PR TITLE
Fix: McuMgrBleTransport now checks if current MTU is valid after Connection (Result)Lock

### DIFF
--- a/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/Source/Bluetooth/McuMgrBleTransport.swift
@@ -391,9 +391,12 @@ extension McuMgrBleTransport: McuMgrTransport {
             writeState.completedWrite(sequenceNumber: sequenceNumber)
         }
         
-        if mtu == nil {
-            mtu = targetPeripheral.maximumWriteValueLength(for: .withoutResponse)
+        let maxNegotiatedMTU = targetPeripheral.maximumWriteValueLength(for: .withoutResponse)
+        if mtu ?? .max > maxNegotiatedMTU {
+            log(msg: "peripheral.maximumWriteValueLength(for: .withoutResponse): \(maxNegotiatedMTU) > Current MTU (\(mtu ?? .max))", atLevel: .debug)
+            mtu = maxNegotiatedMTU
         }
+        
         if chunkSendDataToMtuSize {
             var dataChunks = [Data]()
             var dataChunksSize = 0

--- a/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -404,7 +404,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     /// Error handling here is not considered important because we don't expect many devices to support this.
     /// If this feature is not supported, the upload will take place with default parameters.
     private lazy var mcuManagerParametersCallback: McuMgrCallback<McuMgrParametersResponse> = { [weak self] response, error in
-        guard let self = self else { return }
+        guard let self else { return }
         
         guard error == nil, let response, response.rc.isSupported() else {
             self.log(msg: "Mcu Manager parameters not supported", atLevel: .warning)
@@ -491,15 +491,6 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
                 self.mark(image, as: \.confirmed)
             }
         case .firmwareLoader: // Bare Metal
-            if self.imageManager.transport.mtu > FileSystemManager.SMP_SVR_BT_L2CAP_MTU {
-                self.log(msg: "Patching MTU to \(FileSystemManager.SMP_SVR_BT_L2CAP_MTU).", atLevel: .warning)
-                do {
-                    try self.setUploadMtu(mtu: FileSystemManager.SMP_SVR_BT_L2CAP_MTU)
-                } catch let error {
-                    self.uploadDidFail(with: error)
-                }
-            }
-            
             self.log(msg: "Bare Metal SDK Firmware Loader detected. Overriding target image slot to Primary (zero).", atLevel: .debug)
             self.images = self.images.map {
                 $0.patchForBareMetal()


### PR DESCRIPTION
This explains why making independent API calls, such as an echo or a single mcuMgrParameters before a full-DFU looked smoother, it's because there was a delay that allowed the transport to get a valid MTU value after an active connection was established. Now we check at the lowest level; I attempted to throw an "invalid MTU" value but I think it caused too many issues. Doing it here is sneaky, but it's also the Transport's responsibility? Anyway, things should work better now.