### PR TITLE
Fix: Always match current MTU value with Transport MTU value before issuing Write(s)

### DIFF
--- a/Source/McuMgrUploadPipeline.swift
+++ b/Source/McuMgrUploadPipeline.swift
@@ -27,7 +27,7 @@ public struct McuMgrUploadPipeline {
         
         if let bleTransport = transport as? McuMgrBleTransport {
             bleTransport.numberOfParallelWrites = depth
-            bleTransport.chunkSendDataToMtuSize = bufferSize != 0
+            bleTransport.chunkSendDataToMtuSize = bufferSize != 0 // && bufferSize > mtu ?
         }
     }
     


### PR DESCRIPTION
What the title says. Don't be smart, be boring, check every time. Don't try to guess or estimate the MTU ahead of time. And even if you're connected, don't assume it there, either. Check every time. How many things this will break? I wish I knew...