### PR TITLE
Fix: Wait for BaseViewController's deviceStatusInfo Requests

### DIFF
--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -11,7 +11,7 @@ import iOSMcuManagerLibrary
 
 class DeviceController: UITableViewController, UITextFieldDelegate {
 
-    // MARK: IBOutlet(s)
+    // MARK: @IBOutlet(s)
     
     @IBOutlet weak var connectionStatus: UILabel!
     @IBOutlet weak var mcuMgrParams: UILabel!
@@ -26,11 +26,15 @@ class DeviceController: UITableViewController, UITextFieldDelegate {
     @IBOutlet weak var messageReceived: UILabel!
     @IBOutlet weak var messageReceivedBackground: UIImageView!
     
+    // MARK: @IBAction(s)
+    
     @IBAction func sendTapped(_ sender: UIButton) {
         message.resignFirstResponder()
-        
-        let text = message.text!
-        send(message: text)
+        guard let baseViewController = parent as? BaseViewController else { return }
+        let text = message.text ?? ""
+        baseViewController.onDeviceStatusReady { [unowned self] in
+            send(message: text)
+        }
     }
     
     // MARK: Private Properties

--- a/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileDownloadViewController.swift
@@ -7,10 +7,14 @@
 import UIKit
 import iOSMcuManagerLibrary
 
+// MARK: - FileDownloadViewController
+
 class FileDownloadViewController: UIViewController, McuMgrViewController {
     
     private let recentsKey = "recents"
 
+    // MARK: @IBOutlet(s)
+    
     @IBOutlet weak var file: UITextField!
     @IBOutlet weak var actionOpenRecents: UIButton!
     @IBOutlet weak var actionDownload: UIButton!
@@ -19,9 +23,12 @@ class FileDownloadViewController: UIViewController, McuMgrViewController {
     @IBOutlet weak var fileName: UILabel!
     @IBOutlet weak var fileContent: UILabel!
     
+    // MARK: @IBAction(s)
+    
     @IBAction func nameChanged(_ sender: UITextField) {
         refreshSource()
     }
+    
     @IBAction func openRecents(_ sender: UIButton) {
         let recents = (UserDefaults.standard.array(forKey: recentsKey) ?? []) as! [String]
         
@@ -38,11 +45,15 @@ class FileDownloadViewController: UIViewController, McuMgrViewController {
         alert.popoverPresentationController?.sourceView = sender
         present(alert, animated: true)
     }
+    
     @IBAction func download(_ sender: Any) {
         file.resignFirstResponder()
-        if !file.text!.isEmpty {
-            addRecent(file.text!)
-            _ = fsManager.download(name: source.text!, delegate: self)
+        guard let filename = file.text, let path = source.text,
+              let filesViewController = parent as? FilesController,
+              let baseController = filesViewController.parent as? BaseViewController else { return }
+        addRecent(filename)
+        baseController.onDeviceStatusReady { [unowned self] in
+            _ = fsManager.download(name: path, delegate: self)
         }
     }
     
@@ -87,6 +98,8 @@ class FileDownloadViewController: UIViewController, McuMgrViewController {
         actionOpenRecents.isEnabled = true
     }
 }
+
+// MARK: - FileDownloadDelegate
 
 extension FileDownloadViewController: FileDownloadDelegate {
     

--- a/Example/Example/View Controllers/Manager/FileUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FileUploadViewController.swift
@@ -39,8 +39,9 @@ class FileUploadViewController: UIViewController, McuMgrViewController {
     }
     
     @IBAction func start(_ sender: UIButton) {
-        let downloadViewController = (parent as? FilesController)?.fileDownloadViewController
-        downloadViewController?.addRecent(fileName.text!)
+        guard let destination = destination.text, let fileData,
+              let filesViewController = parent as? FilesController,
+              let baseController = filesViewController.parent as? BaseViewController else { return }
         
         actionStart.isHidden = true
         actionPause.isHidden = false
@@ -48,8 +49,14 @@ class FileUploadViewController: UIViewController, McuMgrViewController {
         actionSelect.isEnabled = false
         status.textColor = .primary
         status.text = "UPLOADING..."
-        _ = fsManager.upload(name: destination.text!, data: fileData!,
-                             delegate: self)
+        
+        if let downloadViewController = filesViewController.fileDownloadViewController {
+            downloadViewController.addRecent(fileName.text!)
+        }
+        baseController.onDeviceStatusReady { [unowned self] in
+            _ = fsManager.upload(name: destination, data: fileData,
+                                 delegate: self)
+        }
     }
     
     @IBAction func pause(_ sender: UIButton) {

--- a/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUploadViewController.swift
@@ -124,12 +124,15 @@ class FirmwareUploadViewController: UIViewController, McuMgrViewController {
     }
     
     @IBAction func start(_ sender: UIButton) {
-        if let envelope = package?.envelope {
-            // SUIT has "no mode" to select
-            // (We use modes in the code only, but SUIT has no concept of upload modes)
-            startFirmwareUpload(envelope: envelope)
-        } else if let package {
-            startFirmwareUpload(package: package)
+        guard let baseController = parent as? BaseViewController else { return }
+        baseController.onDeviceStatusReady { [unowned self] in
+            if let envelope = package?.envelope {
+                // SUIT has "no mode" to select
+                // (We use modes in the code only, but SUIT has no concept of upload modes)
+                startFirmwareUpload(envelope: envelope)
+            } else if let package {
+                startFirmwareUpload(package: package)
+            }
         }
     }
     

--- a/Example/Example/View Controllers/Manager/LogsStatsController.swift
+++ b/Example/Example/View Controllers/Manager/LogsStatsController.swift
@@ -25,7 +25,10 @@ final class LogsStatsController: UITableViewController {
     // MARK: @IBAction(s)
     
     @IBAction func refreshTapped(_ sender: UIButton) {
-        statsManager.list(callback: statsCallback)
+        guard let baseViewController = parent as? BaseViewController else { return }
+        baseViewController.onDeviceStatusReady { [unowned self] in
+            statsManager.list(callback: statsCallback)
+        }
     }
     
     // MARK: statsCallback


### PR DESCRIPTION
Previously, BaseViewController was firing simultaneous requests for mcumgr parameters and others in parallel to an app's operation, such as start DFU. This caused locking issues in the sense that, the transport was reused for DFU and BaseViewController requests, and the supposedly random sequence number was not so random so, different requests happened to land on the same internal 'lock' causing issues. We fixed that by moving the BaseVC to its own private transport, but we then learned that many firmware(s) will not accept these simultaneous requests, so we modified the app to "wait" for BaseVC's requests before making a big operation such as DFU or FileManager.