### PR TITLE
Fix: Don't relaunch BaseViewController's Observability Task on "isDeviceStatusReady" callback

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -273,7 +273,6 @@ extension BaseViewController {
         statusInfoCallback()
         deviceInfoRequested = true
         self.statusInfoCallback = nil
-        launchObservabilityTask()
     }
     
     // MARK: Observability
@@ -354,6 +353,7 @@ extension BaseViewController: PeripheralDelegate {
             otaManager = OTAManager(peripheral.identifier)
             observabilityManager = ObservabilityManager()
             observabilityIdentifier = peripheral.identifier
+            launchObservabilityTask()
         case .disconnecting, .disconnected:
             // Set to false, because a DFU update might change things if that's what happened.
             deviceInfoRequested = false


### PR DESCRIPTION
Basically, if we connect to a Device by any means, and then tap "Check for Updates", the Observability Task will relaunch and reconnect. There's no harm, but there's no need for the app to do that, either. The quick drawback is that Observability's BLE communications are now "in parallel" with SMP, which is unwanted as far as I know. But, tradeoffs. Specially against time.