### PR TITLE
Fix: Detect "Firmware Already up to date" scenario

### DIFF
--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -40,7 +40,7 @@ final class DiagnosticsController: UITableViewController {
     
     @IBAction func observabilityLearnMoreTapped(_ sender: UIButton) {
         guard let baseViewController = parent as? BaseViewController else { return }
-        let alertController = UIAlertController(title: "Observability Help", message: nil, preferredStyle: .alert)
+        let alertController = UIAlertController(title: "Help", message: nil, preferredStyle: .alert)
         alertController.message = """
         
         nRF Cloud Observability is a comprehensive suite of monitoring, diagnostics, and actionable insights for embedded devices. It allows developers and engineering teams to track, analyze, and act on device behavior and reliability in real time.
@@ -241,9 +241,21 @@ extension DiagnosticsController: DeviceStatusDelegate {
         case .connectionClosed:
             observabilityStatus.text = "CLOSED"
             observabilitySectionStatusActivityIndicator.isHidden = true
-        case .unavailable, .errorEvent:
+            
+            observabilitySectionStatusLabel.text = "Status: Offline"
+            observabilitySectionStatusLabel.textColor = .secondaryLabel
+        case .unavailable:
+            observabilityStatus.text = "UNAVAILABLE"
+            observabilitySectionStatusActivityIndicator.isHidden = true
+            
+            observabilitySectionStatusLabel.text = "Status: Unavailable"
+            observabilitySectionStatusLabel.textColor = .secondaryLabel
+        case .errorEvent(let error):
             observabilityStatus.text = "ERROR"
             observabilitySectionStatusActivityIndicator.isHidden = true
+            
+            observabilitySectionStatusLabel.text = "Status: Error \(error.localizedDescription)"
+            observabilitySectionStatusLabel.textColor = .systemRed
         }
     }
 }

--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -203,7 +203,7 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
         otaManager?.getLatestReleaseInfo(deviceInfo: deviceInfo, projectKey: projectKey) { [unowned self] result in
             switch result {
             case .success(let resultInfo):
-                let alertController = UIAlertController(title: "Update Available", message: nil, preferredStyle: .alert)
+                let alertController = UIAlertController(title: "OTA Update Available", message: nil, preferredStyle: .alert)
                 let artifact: ReleaseArtifact! = resultInfo.artifacts.first
                 let revisionString = resultInfo.revision.isEmpty ? "" : "-\(resultInfo.revision)"
                 alertController.message = """
@@ -215,9 +215,15 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
                     download(release: resultInfo)
                 })
                 baseController?.present(alertController, addingCancelAction: true)
-            case .failure(let error):
-                let alertController = UIAlertController(title: "Error Requesting Update", message: error.localizedDescription, preferredStyle: .alert)
-                baseController?.present(alertController, addingCancelAction: true)
+            case .failure(let otaError):
+                if otaError == .deviceIsUpToDate {
+                    let alertController = UIAlertController(title: "Your device is up to date", message: "Your device is already using the latest firmware version available through nRF Cloud OTA.", preferredStyle: .alert)
+                    baseController?.present(alertController, addingCancelAction: true,
+                                            cancelActionTitle: "OK")
+                    return
+                }
+                let alertController = UIAlertController(title: "Error Requesting Update", message: otaError.localizedDescription, preferredStyle: .alert)
+                baseController?.present(alertController, addingCancelAction: true, cancelActionTitle: "OK")
             }
         }
     }

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -65,6 +65,12 @@ public extension OTAManager {
             let responseData = try await network.perform(releaseInfoRequest)
                 .firstValue
             
+            // If we get responseData, the request was success (code 200..299)
+            // However, "up to date" means Server returns no response, or 0 bytes.
+            guard !responseData.isEmpty else {
+                throw OTAManagerError.deviceIsUpToDate
+            }
+            
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             // The .iso8601 decoding strategy does not support fractional seconds.
@@ -167,5 +173,6 @@ public enum OTAManagerError: LocalizedError {
     case incompleteDeviceInfo
     case mdsKeyDecodeError
     case unableToParseResponse
+    case deviceIsUpToDate
     case invalidArtifactURL
 }


### PR DESCRIPTION
We now show a specific alert to the user if there is no update available via nRF Cloud OTA. The implementation is a bit tricky because our current "Network" implementation does not return or allow us to see the status code, it just forwards us back the response Data bytes, which in this care they're empty. The quickest solution was to hijack the catch error path to detect this use case.