### PR TITLE
Fix: Unsupported Devices should be marked as such, instead of with an Error

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -34,7 +34,7 @@ enum nRFCloudStatus {
 // MARK: - ObservabilityStatus
 
 enum ObservabilityStatus {
-    case unavailable(_ error: Error?)
+    case unsupported(_ error: Error?)
     case receivedEvent(_ event: ObservabilityDeviceEvent)
     case connectionClosed
     case errorEvent(_ error: Error)
@@ -289,9 +289,14 @@ extension BaseViewController {
                 }
                 print("STOPPED Listening to \(observabilityIdentifier.uuidString) Connection Events.")
                 observabilityStatus = .connectionClosed
-            } catch let otaError as OTAManagerError {
-                print("CAUGHT OTAManagerError \(otaError.localizedDescription)")
-                observabilityStatus = .unavailable(otaError)
+            } catch let obsError as ObservabilityManagerError {
+                print("CAUGHT ObservabilityManagerError \(obsError.localizedDescription)")
+                switch obsError {
+                case .mdsServiceNotFound:
+                    observabilityStatus = .unsupported(obsError)
+                default:
+                    observabilityStatus = .errorEvent(obsError)
+                }
             } catch let error {
                 print("CAUGHT Error \(error.localizedDescription) Listening to \(observabilityIdentifier.uuidString) Connection Events.")
                 observabilityStatus = .errorEvent(error)

--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -196,7 +196,9 @@ extension DeviceController: DeviceStatusDelegate {
             }
         case .connectionClosed:
             observabilityStatus.text = "CLOSED"
-        case .unavailable, .errorEvent:
+        case .unsupported:
+            observabilityStatus.text = "UNSUPPORTED"
+        case .errorEvent:
             observabilityStatus.text = "ERROR"
         }
     }

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -249,11 +249,11 @@ extension DiagnosticsController: DeviceStatusDelegate {
             
             observabilitySectionStatusLabel.text = "Status: Offline"
             observabilitySectionStatusLabel.textColor = .secondaryLabel
-        case .unavailable:
-            observabilityStatus.text = "UNAVAILABLE"
+        case .unsupported:
+            observabilityStatus.text = "UNSUPPORTED"
             observabilitySectionStatusActivityIndicator.isHidden = true
             
-            observabilitySectionStatusLabel.text = "Status: Unavailable"
+            observabilitySectionStatusLabel.text = "Status: Unsupported"
             observabilitySectionStatusLabel.textColor = .secondaryLabel
         case .errorEvent(let error):
             observabilityStatus.text = "ERROR"

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -156,7 +156,9 @@ extension FilesController: DeviceStatusDelegate {
             }
         case .connectionClosed:
             observabilityStatus.text = "CLOSED"
-        case .unavailable, .errorEvent:
+        case .unsupported:
+            observabilityStatus.text = "UNSUPPORTED"
+        case .errorEvent:
             observabilityStatus.text = "ERROR"
         }
     }

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -173,7 +173,9 @@ extension ImageController: DeviceStatusDelegate {
             }
         case .connectionClosed:
             observabilityStatus.text = "CLOSED"
-        case .unavailable, .errorEvent:
+        case .unsupported:
+            observabilityStatus.text = "UNSUPPORTED"
+        case .errorEvent:
             observabilityStatus.text = "ERROR"
         }
     }


### PR DESCRIPTION
Silly mistake of me to confuse OTAManagerError with ObservabilityManagerError. I mean, both are Errors, and both start with an "O". Brain... something. Brain branch predictor mispredict. This was the penalty.