### PR TITLE
Fix: Disconnect Observability when DFU Starts + Pairing Error Visibility

### DIFF
--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -195,9 +195,11 @@ extension DeviceController: DeviceStatusDelegate {
                 observabilityStatus.text = "STREAMING"
             }
         case .connectionClosed:
-            observabilityStatus.text = "CLOSED"
+            observabilityStatus.text = "DISCONNECTED"
         case .unsupported:
             observabilityStatus.text = "UNSUPPORTED"
+        case .pairingError:
+            observabilityStatus.text = "PAIRING REQUIRED"
         case .errorEvent:
             observabilityStatus.text = "ERROR"
         }

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -244,7 +244,7 @@ extension DiagnosticsController: DeviceStatusDelegate {
                 observabilitySectionStatusUploadedLabel.text = "Uploaded: \(uploadedCount) chunk(s), \(uploadedBytes) bytes"
             }
         case .connectionClosed:
-            observabilityStatus.text = "CLOSED"
+            observabilityStatus.text = "DISCONNECTED"
             observabilitySectionStatusActivityIndicator.isHidden = true
             
             observabilitySectionStatusLabel.text = "Status: Offline"
@@ -259,7 +259,12 @@ extension DiagnosticsController: DeviceStatusDelegate {
             observabilityStatus.text = "ERROR"
             observabilitySectionStatusActivityIndicator.isHidden = true
             
-            observabilitySectionStatusLabel.text = "Status: Error \(error.localizedDescription)"
+            observabilitySectionStatusLabel.text = "Status: \(error.localizedDescription)"
+            observabilitySectionStatusLabel.textColor = .systemRed
+        case .pairingError(let error):
+            observabilityStatus.text = "PAIRING REQUIRED"
+            
+            observabilitySectionStatusLabel.text = "Status: \(error.localizedDescription)"
             observabilitySectionStatusLabel.textColor = .systemRed
         }
     }

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -155,9 +155,11 @@ extension FilesController: DeviceStatusDelegate {
                 observabilityStatus.text = "STREAMING"
             }
         case .connectionClosed:
-            observabilityStatus.text = "CLOSED"
+            observabilityStatus.text = "DISCONNECTED"
         case .unsupported:
             observabilityStatus.text = "UNSUPPORTED"
+        case .pairingError:
+            observabilityStatus.text = "PAIRING REQUIRED"
         case .errorEvent:
             observabilityStatus.text = "ERROR"
         }

--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -407,6 +407,8 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
         
         initialBytes = 0
         uploadImageSize = nil
+        
+        baseController?.onDFUStart()
     }
     
     func upgradeStateDidChange(from previousState: FirmwareUpgradeState, to newState: FirmwareUpgradeState) {

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -172,9 +172,11 @@ extension ImageController: DeviceStatusDelegate {
                 observabilityStatus.text = "STREAMING"
             }
         case .connectionClosed:
-            observabilityStatus.text = "CLOSED"
+            observabilityStatus.text = "DISCONNECTED"
         case .unsupported:
             observabilityStatus.text = "UNSUPPORTED"
+        case .pairingError:
+            observabilityStatus.text = "PAIRING REQUIRED"
         case .errorEvent:
             observabilityStatus.text = "ERROR"
         }

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -30,6 +30,12 @@ public final class OTAManager {
         _ = ble.centralManager.state
         self.network = Network("api.memfault.com")
     }
+    
+    // MARK: deinit
+    
+    deinit {
+        print(#function)
+    }
 }
 
 // MARK: - API

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
@@ -41,6 +41,12 @@ public final class ObservabilityManager {
         // Try to start inner CentralManager.
         _ = ble.centralManager.state
     }
+    
+    // MARK: deinit
+    
+    deinit {
+        print(#function)
+    }
 }
 
 // MARK: - Bluetooth


### PR DESCRIPTION
When starting DFU from OTA, or with OTA / Observability working, they'd inevitably switch to an "Error" status during DFU. Makes sense. So before that, we disconnect / stop listening for Observability events. I mean, I think this makes sense, the device is quite busy with the DFU operation.