### PR TITLE
Fix for ObservabilityManager Retain Cycle + Enabled Observability on iOS 13.0 and above (previously required 15)

### DIFF
--- a/iOSOtaLibrary/Source/Observability/ObservabilityManagerError.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManagerError.swift
@@ -19,8 +19,6 @@ public enum ObservabilityManagerError: LocalizedError {
     case unableToReadDeviceURI
     case unableToReadAuthData
     case missingAuthData
-    
-    case iOSVersionTooLow(_ string: String)
 
     public var errorDescription: String? {
         switch self {
@@ -38,8 +36,6 @@ public enum ObservabilityManagerError: LocalizedError {
             return "Unable to read Authentication Data."
         case .missingAuthData:
             return "Missing Authentication Data."
-        case .iOSVersionTooLow(let string):
-            return string
         }
     }
 }


### PR DESCRIPTION
The issue seems to be in the inner Task launched inside listenForChunks(). As soon as we start listening to peripheral events / received Data, there's a retain cycle going on. Took a while to track exactly which line of code caused it, but it was the for try await loop. I don't think there's anything specifically wrong, I guess it's because it's a Task inside of a Task already, so there must be some hidden chain of strong references I'm missing. And yes of course, we added [weak self] everywhere to try to solve it. But in the end, this solved two issues with the same stone.