### PR TITLE
Updated code to reflect fixed TODO

### DIFF
--- a/Example/Example/Util/DeviceInfoManager.swift
+++ b/Example/Example/Util/DeviceInfoManager.swift
@@ -141,10 +141,7 @@ extension DeviceInfoManager {
             .timeout(5, scheduler: DispatchQueue.main)
             .firstValue
         
-        // TODO: Fix bug. Should be possible to do mdsServices.first here.
-        guard let mdsService = mdsServices.first(where: { $0.uuid == mdsUUID }) else {
-            return nil
-        }
+        guard let mdsService = mdsServices.first else { return nil }
         let discoveredCharacteristics = try await peripheral.discoverCharacteristics([], for: mdsService)
             .firstValue
         for characteristic in discoveredCharacteristics {

--- a/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/NordicSemiconductor/IOS-BLE-Library.git",
       "state" : {
         "branch" : "main",
-        "revision" : "bf172c69c0d2488072808cf18314ada21d7864e9"
+        "revision" : "9105af2faf0cc1eb825306bf0190905da80adb7c"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weichsel/ZIPFoundation.git",
       "state" : {
-        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
-        "version" : "0.9.19"
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],


### PR DESCRIPTION
The peripheral.discoverServices() is now filtering as expected, so this change is to reflect that in the code.