### PR TITLE
Fix: Detect Unreachable Network

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -194,6 +194,8 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
         baseController?.present(alertController, addingCancelAction: true)
     }
     
+    // MARK: requestLatestReleaseInfo(for:using:)
+    
     private func requestLatestReleaseInfo(for deviceInfo: DeviceInfoToken,
                                           using projectKey: ProjectKey) {
         otaManager?.getLatestReleaseInfo(deviceInfo: deviceInfo, projectKey: projectKey) { [unowned self] result in
@@ -212,15 +214,24 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
                 })
                 baseController?.present(alertController, addingCancelAction: true)
             case .failure(let otaError):
-                if otaError == .deviceIsUpToDate {
-                    let alertController = UIAlertController(title: "Your device is up to date", message: "Your device is already using the latest firmware version available through nRF Cloud OTA.", preferredStyle: .alert)
-                    baseController?.present(alertController, addingCancelAction: true,
-                                            cancelActionTitle: "OK")
-                    return
-                }
-                let alertController = UIAlertController(title: "Error Requesting Update", message: otaError.localizedDescription, preferredStyle: .alert)
-                baseController?.present(alertController, addingCancelAction: true, cancelActionTitle: "OK")
+                handleLatestReleaseError(otaError)
             }
+        }
+    }
+    
+    private func handleLatestReleaseError(_ otaError: OTAManagerError) {
+        switch otaError {
+        case .networkError:
+            let alertController = UIAlertController(title: "Network Error", message: "Unable to reach the Network.", preferredStyle: .alert)
+            baseController?.present(alertController, addingCancelAction: true,
+                                    cancelActionTitle: "OK")
+        case .deviceIsUpToDate:
+            let alertController = UIAlertController(title: "Your device is up to date", message: "Your device is already using the latest firmware version available through nRF Cloud OTA.", preferredStyle: .alert)
+            baseController?.present(alertController, addingCancelAction: true,
+                                    cancelActionTitle: "OK")
+        default:
+            let alertController = UIAlertController(title: "Error Requesting Update", message: otaError.localizedDescription, preferredStyle: .alert)
+            baseController?.present(alertController, addingCancelAction: true, cancelActionTitle: "OK")
         }
     }
     

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -88,6 +88,8 @@ public extension OTAManager {
                 throw OTAManagerError.unableToParseResponse
             }
             return releaseInfo
+        } catch let networkError as URLError {
+            throw OTAManagerError.networkError
         } catch {
             throw error
         }
@@ -164,6 +166,7 @@ public enum OTAManagerError: LocalizedError {
     case incompleteDeviceInfo
     case mdsKeyDecodeError
     case unableToParseResponse
+    case networkError
     case deviceIsUpToDate
     case invalidArtifactURL
     case sha256HashMismatch


### PR DESCRIPTION
This is not the best, because, our "Network" code implementation is duplicated here and in iOS-Common. I think now we have some more bandwidth to bring the minimum version of iOS-Common down and be able to solve this for the future. But for now, this fixes issue https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/447