### PR TITLE
Bumped SwiftCBOR Dependency version from 0.4.7 to 0.5.0

### DIFF
--- a/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/valpackett/SwiftCBOR.git",
       "state" : {
-        "revision" : "418dab41b09a5da0d45d7b788c59085979ff4dae",
-        "version" : "0.4.7"
+        "revision" : "04ccff117f6549121d5721ec84fdf0162122b90e",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/valpackett/SwiftCBOR.git",
-            .exact("0.4.7")
+            .exact("0.5.0")
         ),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git",
             .upToNextMajor(from: "0.9.0")


### PR DESCRIPTION
Promoted by: https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/395