### PR TITLE
Target iOS-Common-Lib "13" branch

### DIFF
--- a/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NordicPlayground/IOS-Common-Libraries",
       "state" : {
-        "branch" : "main",
+        "branch" : "13",
         "revision" : "7ee70398d8ada2359404ad4b9967af98cd85f2d3"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             .branchItem("main")
         ),
         .package(url: "https://github.com/NordicPlayground/IOS-Common-Libraries",
-            .branchItem("main")
+            .branchItem("13")
         )
     ],
     targets: [


### PR DESCRIPTION
In the end, this is the current solution for our woe of iOS-Common's shaders not compiling for iOS 15 equivalents and above. The library is full 13-backwards compatible, but we keep a separate branch, 13, to allow this backwards-compatible behaviour.