### PR TITLE
Fix: Observability Chunks are now uploaded in-order (received Order)

### DIFF
--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
@@ -30,6 +30,9 @@ public final class ObservabilityManager {
     internal var deviceContinuations: [UUID: AsyncObservabilityStream.Continuation]
     internal var deviceCancellables: [UUID: Set<AnyCancellable>]
     
+    internal var pendingUploads = [(ObservabilityAuth, ObservabilityChunk)]()
+    internal var networkBusy = false
+    
     // MARK: init
     
     public init() {


### PR DESCRIPTION
The backend expects, or would like, chunks to be uploaded in-order. Turns out making requests in parallel is not what we wanted for this. I tried multiple ways to get a native Combine implementation for this. There are ways to do this, but they require iOS 15 due to using async sequences and ".values". Apparently nobody in the Internet does anything below iOS 15 but, common-logic applies here. Perhaps not the prettiest solution, specially due to the user of "Main" but, hey, it works.

GitHub Issue: https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/457