### PR TITLE
Fix for Broken SUIT McuMgrPackage(s)

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
@@ -43,7 +43,7 @@ public class ImageManager: McuManager {
          */
         public init(name: String? = nil, image: Int, slot: Int = 1,
                     content: McuMgrManifest.File.ContentType = .unknown, hash: Data, data: Data) {
-            self.name = nil
+            self.name = name
             self.image = image
             self.slot = slot % 2
             self.content = content


### PR DESCRIPTION
Silly mistake. If the argument already defaults to nil if not provided, no need to forcefully assign it to nil here.