### PR TITLE
Change: Default ImageManager.Name, if not given, is now the file's content @description

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
@@ -52,7 +52,7 @@ public class ImageManager: McuManager {
         }
         
         internal init(_ image: FirmwareUpgradeImage) {
-            self.name = nil
+            self.name = image.content.description
             self.image = image.image
             // Note that FirmwareUpgradeImage is itself derived from ImageManager.Image, so
             // there's no need to repeat the fix for the slot.


### PR DESCRIPTION
Since we have the content, so at least some form of information regarding what we're representing, makes sense to use it here. It's at least user-visible, and makes it easy for 3rd party apps to use. Less edge cases.