### PR TITLE
Implemented basic Save / Restore from Disk functionality

### DIFF
--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
@@ -41,6 +41,7 @@ public final class ObservabilityManager {
         self.devices = [UUID: ObservabilityDevice]()
         self.deviceContinuations = [UUID: AsyncObservabilityStream.Continuation]()
         self.deviceCancellables = [UUID: Set<AnyCancellable>]()
+        self.state.restoreFromDisk()
     }
     
     // MARK: deinit


### PR DESCRIPTION
This is a precursor to us being able to "save" chunks that have not been uploaded due to any kind of network error. Then, on reconnection, we can recover the missing chunks as well as the new ones, and re-send them.