### PR TITLE
API Cleanup

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -333,9 +333,9 @@ extension BaseViewController {
     
     private func processObservabilityEvent(_ observabilityEvent: ObservabilityDeviceEvent) {
         switch observabilityEvent {
-        case .updatedChunk(let chunk, let status):
-            switch status {
-            case .receivedAndPendingUpload:
+        case .updatedChunk(let chunk):
+            switch chunk.status {
+            case .pendingUpload:
                 observabilityPendingBytes += chunk.data.count
                 observabilityPendingChunks += 1
             case .success:

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -232,9 +232,9 @@ extension DiagnosticsController: DeviceStatusDelegate {
                     observabilitySectionStatusLabel.textColor = .secondaryLabel
                 }
                 showObservabilityActivityIndicator(isTrue)
-            case .updatedChunk(let chunk, let chunkStatus):
-                switch chunkStatus {
-                case .receivedAndPendingUpload:
+            case .updatedChunk(let chunk):
+                switch chunk.status {
+                case .pendingUpload:
                     observabilitySectionStatusLabel.text = "Status: Pending Upload"
                     observabilitySectionStatusLabel.textColor = .systemYellow
                 case .uploading:

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityChunk.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityChunk.swift
@@ -16,7 +16,7 @@ public struct ObservabilityChunk: Identifiable, Hashable, Codable {
     // MARK: Status
     
     public enum Status: Equatable, Hashable, Codable {
-        case receivedAndPendingUpload
+        case pendingUpload
         case uploading
         case success
         case errorUploading
@@ -41,7 +41,7 @@ public struct ObservabilityChunk: Identifiable, Hashable, Codable {
         self.sequenceNumber = data.first ?? .max
         self.data = data.dropFirst()
         self.timestamp = Date()
-        self.status = .receivedAndPendingUpload
+        self.status = .pendingUpload
     }
     
     // MARK: Hashable

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDevice.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDevice.swift
@@ -19,7 +19,6 @@ struct ObservabilityDevice {
     var isNotifying: Bool
     var isStreaming: Bool
     var auth: ObservabilityAuth?
-    var chunks: [ObservabilityChunk]
     
     // MARK: init
     
@@ -29,6 +28,5 @@ struct ObservabilityDevice {
         self.isNotifying = false
         self.isStreaming = false
         self.auth = nil
-        self.chunks = [ObservabilityChunk]()
     }
 }

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
@@ -18,7 +18,7 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
     
     case notifications(_ enabled: Bool), streaming(_ enabled: Bool)
     case authenticated(_ auth: ObservabilityAuth)
-    case updatedChunk(_ chunk: ObservabilityChunk, status: ObservabilityChunk.Status)
+    case updatedChunk(_ chunk: ObservabilityChunk)
     
     // MARK: CustomStringConvertible
     
@@ -34,8 +34,8 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
             return ".streaming(\(enabled ? "enabled" : "disabled"))"
         case .authenticated(_):
             return ".authenticated(_)"
-        case .updatedChunk(let chunk, status: let status):
-            return ".updatedChunk(\(chunk.sequenceNumber), \(String(describing: status))"
+        case .updatedChunk(let chunk):
+            return ".updatedChunk(\(chunk.sequenceNumber), \(String(describing: chunk.status))"
         }
     }
 }

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
@@ -35,7 +35,16 @@ struct ObservabilityState: Codable {
         return pendingUploads[identifier]?.first
     }
     
-    mutating func finishedUploading(_ chunk: ObservabilityChunk, from identifier: UUID) {
+    @discardableResult
+    mutating func update(_ chunk: ObservabilityChunk, from identifier: UUID, to status: ObservabilityChunk.Status) -> ObservabilityChunk {
+        guard let index = pendingUploads[identifier]?.firstIndex(of: chunk) else {
+            return chunk
+        }
+        pendingUploads[identifier]?[index].status = status
+        return pendingUploads[identifier]?[index] ?? chunk
+    }
+    
+    mutating func clear(_ chunk: ObservabilityChunk, from identifier: UUID) {
         guard let index = pendingUploads[identifier]?.firstIndex(of: chunk) else {
             return
         }


### PR DESCRIPTION
It was a good step to delay publishing the previous version. Because now it's cleaner, even though on our implementation side it's a bit of a mess because of struct equality.