### PR TITLE
Report back to API User Pending Uploads on Connection

### DIFF
--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityChunk.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityChunk.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // MARK: - ObservabilityChunk
 
-public struct ObservabilityChunk: Identifiable, Hashable, Codable {
+public struct ObservabilityChunk: Identifiable, Hashable, Comparable, Codable {
     
     // MARK: Status
     
@@ -51,5 +51,14 @@ public struct ObservabilityChunk: Identifiable, Hashable, Codable {
         hasher.combine(data)
         hasher.combine(status)
         hasher.combine(timestamp)
+    }
+    
+    // MARK: Comparable
+    
+    public static func < (lhs: ObservabilityChunk, rhs: ObservabilityChunk) -> Bool {
+        guard lhs.timestamp < rhs.timestamp else {
+            return lhs.sequenceNumber < rhs.sequenceNumber
+        }
+        return lhs.timestamp < rhs.timestamp
     }
 }

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
@@ -25,9 +25,7 @@ struct ObservabilityState: Codable {
         }
         
         pendingUploads[identifier]?.append(contentsOf: chunks)
-        pendingUploads[identifier]?.sorted {
-            return $0.sequenceNumber < $1.sequenceNumber && $0.timestamp < $1.timestamp
-        }
+        pendingUploads[identifier]?.sorted(by: <)
         saveToDisk()
     }
     


### PR DESCRIPTION
This is to proof we are saving state of previous uploads that could not be sent.