### PR TITLE
ObservabilityManager can now continue saved pending uploads

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -308,7 +308,7 @@ extension BaseViewController {
                 }
                 print("STOPPED Listening to \(observabilityIdentifier.uuidString) Connection Events.")
                 observabilityStatus = .connectionClosed
-            } catch let obsError as ObservabilityManagerError {
+            } catch let obsError as ObservabilityError {
                 print("CAUGHT ObservabilityManagerError \(obsError.localizedDescription)")
                 switch obsError {
                 case .mdsServiceNotFound:

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -242,9 +242,9 @@ extension DiagnosticsController: DeviceStatusDelegate {
                 case .success:
                     observabilitySectionStatusLabel.text = "Status: Awaiting New Chunks"
                     observabilitySectionStatusLabel.textColor = .systemGreen
-                case .errorUploading:
-                    observabilitySectionStatusLabel.text = "Error Uploading Chunk \(chunk.sequenceNumber)"
-                    observabilitySectionStatusLabel.textColor = .systemRed
+                case .uploadError:
+                    // Should be handled by .errorEvent
+                    break
                 }
                 
                 showObservabilityActivityIndicator(true)

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityChunk.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityChunk.swift
@@ -19,7 +19,7 @@ public struct ObservabilityChunk: Identifiable, Hashable, Comparable, Codable {
         case pendingUpload
         case uploading
         case success
-        case errorUploading
+        case uploadError
     }
     
     // MARK: Properties

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
@@ -1,6 +1,7 @@
 //
-//  MemfaultDeviceEvent.swift
+//  ObservabilityDeviceEvent.swift
 //  iOS-nRF-Memfault-Library
+//  iOSOtaLibrary
 //
 //  Created by Dinesh Harjani on 26/8/22.
 //  Copyright © 2025 Nordic Semiconductor ASA. All rights reserved.
@@ -8,7 +9,7 @@
 
 import Foundation
 
-// MARK: - MemfaultDeviceEvent
+// MARK: - ObservabilityDeviceEvent
 
 public enum ObservabilityDeviceEvent: CustomStringConvertible {
     

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
@@ -15,7 +15,7 @@ struct ObservabilityState: Codable {
     
     // MARK: Properties
     
-    internal var pendingUploads = [UUID: [ObservabilityChunk]]()
+    private var pendingUploads = [UUID: [ObservabilityChunk]]()
     
     // MARK: API
     
@@ -27,10 +27,6 @@ struct ObservabilityState: Codable {
         pendingUploads[identifier]?.append(contentsOf: chunks)
         pendingUploads[identifier]?.sorted(by: <)
         saveToDisk()
-    }
-    
-    func nextChunk(for identifier: UUID) -> ObservabilityChunk? {
-        return pendingUploads[identifier]?.first
     }
     
     @discardableResult
@@ -48,6 +44,14 @@ struct ObservabilityState: Codable {
         }
         pendingUploads[identifier]?.remove(at: index)
         saveToDisk()
+    }
+    
+    func pendingChunks(for identifier: UUID) -> [ObservabilityChunk] {
+        return pendingUploads[identifier] ?? []
+    }
+    
+    func nextChunk(for identifier: UUID) -> ObservabilityChunk? {
+        return pendingChunks(for: identifier).first
     }
 }
 

--- a/iOSOtaLibrary/Source/Observability/ObservabilityError.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityError.swift
@@ -1,5 +1,5 @@
 //
-//  ObservabilityManagerError.swift
+//  ObservabilityError.swift
 //  iOSOtaLibrary
 //
 //  Created by Dinesh Harjani on 8/9/25.
@@ -8,18 +8,24 @@
 
 import Foundation
 
-// MARK: - ObservabilityManagerError
+// MARK: - ObservabilityError
 
-public enum ObservabilityManagerError: LocalizedError {
+public enum ObservabilityError: LocalizedError {
+    
+    // BLE Connection
     case bleUnavailable
     case peripheralNotFound
     case pairingError
     case mdsServiceNotFound
     case mdsDataExportCharacteristicNotFound
     
+    // Authentication
     case unableToReadDeviceURI
     case unableToReadAuthData
     case missingAuthData
+    
+    // Networking
+    case unableToUploadChunk
 
     public var errorDescription: String? {
         switch self {
@@ -39,6 +45,8 @@ public enum ObservabilityManagerError: LocalizedError {
             return "Unable to read Authentication Data."
         case .missingAuthData:
             return "Missing Authentication Data."
+        case .unableToUploadChunk:
+            return "Unable to upload chunk due to network issue."
         }
     }
 }

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Logs.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Logs.swift
@@ -1,0 +1,33 @@
+//
+//  ObservabilityManager+Logs.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 5/11/25.
+//  Copyright © 2025 Nordic Semiconductor ASA. All rights reserved.
+//
+
+import Foundation
+import iOS_Common_Libraries
+
+// MARK: - Logs
+
+extension ObservabilityManager {
+    
+    func log(_ string: String) {
+        guard #available(iOS 14.0, *) else {
+            print(string)
+            return
+        }
+        let log = NordicLog(Self.self, subsystem: "com.nordicsemi.ios_ota_library")
+        log.debug(string)
+    }
+    
+    func logError(_ string: String) {
+        guard #available(iOS 14.0, *) else {
+            print("Error: \(string)")
+            return
+        }
+        let log = NordicLog(Self.self, subsystem: "com.nordicsemi.ios_ota_library")
+        log.error(string)
+    }
+}


### PR DESCRIPTION
Not sure if the API works 100% yet from the other side, but it looks like we are doing the main things right: saving chunks to disk that we can't send, and when we can, we send them again.