### PR TITLE
Implemented Offline Caching of Pending Chunks

### DIFF
--- a/Example/Example/Util/ObservabilityStatus.swift
+++ b/Example/Example/Util/ObservabilityStatus.swift
@@ -37,6 +37,8 @@ enum ObservabilityStatus: CustomStringConvertible {
                 return "AUTHENTICATED"
             case .updatedChunk:
                 return "STREAMING"
+            case .unableToUpload:
+                return "NETWORK UNAVAILABLE"
             }
         case .connectionClosed:
             return "DISCONNECTED"

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -249,6 +249,10 @@ extension DiagnosticsController: DeviceStatusDelegate {
                 
                 showObservabilityActivityIndicator(true)
                 updatePendingAndUploadedLabels(pendingBytes: pendingBytes, pendingCount: pendingCount, uploadedBytes: uploadedBytes, uploadedCount: uploadedCount)
+            case .unableToUpload:
+                showObservabilityActivityIndicator(true)
+                observabilitySectionStatusLabel.text = "Status: Network Unavailable"
+                observabilitySectionStatusLabel.textColor = .systemYellow
             }
         case .connectionClosed:
             showObservabilityActivityIndicator(false)

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
@@ -21,6 +21,8 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
     case authenticated(_ auth: ObservabilityAuth)
     case updatedChunk(_ chunk: ObservabilityChunk)
     
+    case unableToUpload
+    
     // MARK: CustomStringConvertible
     
     public var description: String {
@@ -37,6 +39,8 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
             return ".authenticated(_)"
         case .updatedChunk(let chunk):
             return ".updatedChunk(\(chunk.sequenceNumber), \(String(describing: chunk.status))"
+        case .unableToUpload:
+            return ".unableToUpload"
         }
     }
 }

--- a/iOSOtaLibrary/Source/Observability/ObservabilityError.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityError.swift
@@ -23,9 +23,6 @@ public enum ObservabilityError: LocalizedError {
     case unableToReadDeviceURI
     case unableToReadAuthData
     case missingAuthData
-    
-    // Networking
-    case unableToUploadChunk
 
     public var errorDescription: String? {
         switch self {
@@ -45,8 +42,6 @@ public enum ObservabilityError: LocalizedError {
             return "Unable to read Authentication Data."
         case .missingAuthData:
             return "Missing Authentication Data."
-        case .unableToUploadChunk:
-            return "Unable to upload chunk due to network issue."
         }
     }
 }

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
@@ -20,6 +20,7 @@ internal extension ObservabilityManager {
     func connectAndAuthenticate(from identifier: UUID) async {
         do {
             try await ble.isPoweredOn()
+            log(#function)
             
             guard let cbPeripheral = ble.retrievePeripherals(withIdentifiers: [identifier])
                 .first else {
@@ -215,8 +216,7 @@ extension ObservabilityManager {
                     let updatedChunk = state.update(uploadingChunk, from: identifier, to: .uploadError)
                     deviceContinuations[identifier]?.yield((identifier, .updatedChunk(updatedChunk)))
                     networkBusy = false
-                    deviceContinuations[identifier]?.yield(with: .failure(ObservabilityError.unableToUploadChunk))
-                    disconnect(from: identifier)
+                    deviceContinuations[identifier]?.yield((identifier, .unableToUpload))
                 }
             } receiveValue: { [weak self] resultData in
                 guard let self else { return }

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
@@ -68,6 +68,9 @@ public extension ObservabilityManager {
         let asyncObservabilityDeviceStream = AsyncObservabilityStream() { continuation in
             // To-Do: Is there a previous one?
             deviceContinuations[identifier] = continuation
+            continuation.onTermination = { @Sendable [weak self] termination in
+                self?.log("Detected AsyncObservabilityStream termination.")
+            }
         }
         
         Task {
@@ -98,6 +101,8 @@ public extension ObservabilityManager {
         guard let device = devices[identifier],
               let peripheral = peripherals[identifier],
               let continuation = deviceContinuations[identifier] else { return }
+        
+        log(#function)
         do {
             if device.isStreaming {
                 guard let mdsService = peripheral.services?.first(where: { $0.uuid == CBUUID.MDS }),
@@ -126,6 +131,7 @@ public extension ObservabilityManager {
             continuation.finish()
         } catch {
             continuation.finish(throwing: error)
+            logError("Error when attempting to disconnect: \(error.localizedDescription)")
         }
     }
     


### PR DESCRIPTION
When there is an error during upload, we no longer disconnect over BLE from the device. Instead, we keep receiving chunks until we disconnect from the device for other reasons. When connection is restored, upload can then proceed. This mirrors behaviours we provide for other platforms.