### PR TITLE
Cleanup of Pairing Error

### DIFF
--- a/Example/Example/Util/ObservabilityStatus.swift
+++ b/Example/Example/Util/ObservabilityStatus.swift
@@ -16,7 +16,7 @@ enum ObservabilityStatus: CustomStringConvertible {
     case unsupported(_ error: Error?)
     case receivedEvent(_ event: ObservabilityDeviceEvent)
     case connectionClosed
-    case pairingError(_ error: CBATTError)
+    case pairingError
     case errorEvent(_ error: Error)
     
     var description: String {

--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -346,17 +346,15 @@ extension BaseViewController {
                 switch obsError {
                 case .mdsServiceNotFound:
                     observabilityStatus = .unsupported(obsError)
+                case .pairingError:
+                    observabilityStatus = .pairingError
                 default:
                     observabilityStatus = .errorEvent(obsError)
                 }
                 stopObservabilityManagerAndTask()
             } catch let error {
                 print("CAUGHT Error \(error.localizedDescription) Listening to \(observabilityIdentifier.uuidString) Connection Events.")
-                if let cbError = error as? CBATTError, cbError.code == .insufficientEncryption {
-                    observabilityStatus = .pairingError(cbError)
-                } else {
-                    observabilityStatus = .errorEvent(error)
-                }
+                observabilityStatus = .errorEvent(error)
                 stopObservabilityManagerAndTask()
             }
         }

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -283,8 +283,8 @@ extension DiagnosticsController: DeviceStatusDelegate {
             observabilitySectionStatusLabel.text = "Status: \(error.localizedDescription)"
             observabilitySectionStatusLabel.textColor = .systemRed
             observabilityButton.setTitle("Reconnect", for: .normal)
-        case .pairingError(let error):
-            observabilitySectionStatusLabel.text = "Status: \(error.localizedDescription)"
+        case .pairingError:
+            observabilitySectionStatusLabel.text = "Status: Pairing Error"
             observabilitySectionStatusLabel.textColor = .systemRed
             observabilityButton.setTitle("Reconnect", for: .normal)
         }


### PR DESCRIPTION
Observability already returns a specific error for pairing issues. So there's no need for us to have specific logic for that.