### PR TITLE
Fix: Reset pending chunks & bytes to send on connection

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -364,6 +364,10 @@ extension BaseViewController {
     
     private func processObservabilityEvent(_ observabilityEvent: ObservabilityDeviceEvent) {
         switch observabilityEvent {
+        case .connected:
+            // Reset since on Observability Connection we'll get a report of pending chunks.
+            observabilityPendingBytes = 0
+            observabilityPendingChunks = 0
         case .updatedChunk(let chunk):
             switch chunk.status {
             case .pendingUpload:

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
@@ -191,7 +191,7 @@ extension ObservabilityManager {
     // MARK: received
     
     func received(_ chunk: ObservabilityChunk, from identifier: UUID) {
-        log("Received Chunk Seq. Number \(chunk.sequenceNumber)")
+        log("Received Chunk Seq. Number \(chunk.sequenceNumber) with Timestamp: \(chunk.timestamp)")
         state.add([chunk], for: identifier)
         deviceContinuations[identifier]?.yield((identifier, .updatedChunk(chunk)))
     }
@@ -200,7 +200,7 @@ extension ObservabilityManager {
     
     func upload(_ chunk: ObservabilityChunk, with auth: ObservabilityAuth, from identifier: UUID) {
         guard deviceCancellables[identifier] != nil else { return }
-        log("Uploading Chunk Seq. Number \(chunk.sequenceNumber)")
+        log("Uploading Chunk Seq. Number \(chunk.sequenceNumber) with Timestamp: \(chunk.timestamp)")
         
         let uploadingChunk = state.update(chunk, from: identifier, to: .uploading)
         deviceContinuations[identifier]?.yield((identifier, .updatedChunk(uploadingChunk)))
@@ -220,7 +220,7 @@ extension ObservabilityManager {
                 }
             } receiveValue: { [weak self] resultData in
                 guard let self else { return }
-                log("Uploaded Chunk Seq. Number \(uploadingChunk.sequenceNumber)")
+                log("Uploaded Chunk Seq. Number \(uploadingChunk.sequenceNumber) with Timestamp: \(chunk.timestamp)")
                 let successfulChunk = state.update(uploadingChunk, from: identifier, to: .success)
                 deviceContinuations[identifier]?.yield((identifier, .updatedChunk(successfulChunk)))
                 state.clear(successfulChunk, from: identifier)


### PR DESCRIPTION
ObservabilityManager reports pending chunks on connection. So we need to clear these to match.