### PR TITLE
Cleanup: .unableToUpload Events are not needed since we already have streaming(false)

### DIFF
--- a/Example/Example/Util/ObservabilityStatus.swift
+++ b/Example/Example/Util/ObservabilityStatus.swift
@@ -32,13 +32,11 @@ enum ObservabilityStatus: CustomStringConvertible {
             case .notifications(let enabled):
                 return enabled ? "NOTIFYING" : "NOTIFICATIONS DISABLED"
             case .streaming(let isTrue):
-                return isTrue ? "STREAMING" : "NOT STREAMING"
+                return isTrue ? "ONLINE" : "NETWORK UNAVAILABLE"
             case .authenticated:
                 return "AUTHENTICATED"
             case .updatedChunk:
                 return "STREAMING"
-            case .unableToUpload:
-                return "NETWORK UNAVAILABLE"
             }
         case .connectionClosed:
             return "DISCONNECTED"

--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -315,7 +315,7 @@ extension BaseViewController {
         switch observabilityStatus {
         case .receivedEvent(let event):
             switch event {
-            case .unableToUpload:
+            case .streaming(false):
                 do {
                     try observabilityManager?.continuePendingUploads(for: observabilityIdentifier)
                 } catch {

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -236,10 +236,11 @@ extension DiagnosticsController: DeviceStatusDelegate {
                     observabilitySectionStatusLabel.text = "Status: Online"
                     observabilitySectionStatusLabel.textColor = .systemGreen
                 } else {
-                    observabilitySectionStatusLabel.text = "Status: Offline"
-                    observabilitySectionStatusLabel.textColor = .secondaryLabel
+                    observabilitySectionStatusLabel.text = "Status: Network Unavailable"
+                    observabilitySectionStatusLabel.textColor = .systemYellow
+                    observabilityButton.setTitle("Retry Network", for: .normal)
                 }
-                showObservabilityActivityIndicator(isTrue)
+                showObservabilityActivityIndicator(true)
             case .updatedChunk(let chunk):
                 switch chunk.status {
                 case .pendingUpload:
@@ -259,11 +260,6 @@ extension DiagnosticsController: DeviceStatusDelegate {
                 
                 showObservabilityActivityIndicator(true)
                 updatePendingAndUploadedLabels(pendingBytes: pendingBytes, pendingCount: pendingCount, uploadedBytes: uploadedBytes, uploadedCount: uploadedCount)
-            case .unableToUpload:
-                showObservabilityActivityIndicator(true)
-                observabilitySectionStatusLabel.text = "Status: Network Unavailable"
-                observabilitySectionStatusLabel.textColor = .systemYellow
-                observabilityButton.setTitle("Retry Network", for: .normal)
             }
         case .connectionClosed:
             showObservabilityActivityIndicator(false)

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
@@ -21,8 +21,6 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
     case authenticated(_ auth: ObservabilityAuth)
     case updatedChunk(_ chunk: ObservabilityChunk)
     
-    case unableToUpload
-    
     // MARK: CustomStringConvertible
     
     public var description: String {
@@ -39,8 +37,6 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
             return ".authenticated(_)"
         case .updatedChunk(let chunk):
             return ".updatedChunk(\(chunk.sequenceNumber), \(String(describing: chunk.status))"
-        case .unableToUpload:
-            return ".unableToUpload"
         }
     }
 }

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
@@ -228,7 +228,7 @@ extension ObservabilityManager {
                     let updatedChunk = state.update(uploadingChunk, from: identifier, to: .uploadError)
                     deviceContinuations[identifier]?.yield((identifier, .updatedChunk(updatedChunk)))
                     networkBusy = false
-                    deviceContinuations[identifier]?.yield((identifier, .unableToUpload))
+                    deviceContinuations[identifier]?.yield((identifier, .streaming(false)))
                     enqueueRetryPendingUploads(for: identifier, with: auth)
                 }
             } receiveValue: { [weak self] resultData in


### PR DESCRIPTION
We can just reuse what'a already present. That was an oversight on my part.