### PR TITLE
Renamed .streaming() ObservabilityEvents to .online()

### DIFF
--- a/Example/Example/Util/ObservabilityStatus.swift
+++ b/Example/Example/Util/ObservabilityStatus.swift
@@ -31,7 +31,7 @@ enum ObservabilityStatus: CustomStringConvertible {
                 return "DISCONNECTED"
             case .notifications(let enabled):
                 return enabled ? "NOTIFYING" : "NOTIFICATIONS DISABLED"
-            case .streaming(let isTrue):
+            case .online(let isTrue):
                 return isTrue ? "ONLINE" : "NETWORK UNAVAILABLE"
             case .authenticated:
                 return "AUTHENTICATED"

--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -315,7 +315,7 @@ extension BaseViewController {
         switch observabilityStatus {
         case .receivedEvent(let event):
             switch event {
-            case .streaming(false):
+            case .online(false):
                 do {
                     try observabilityManager?.continuePendingUploads(for: observabilityIdentifier)
                 } catch {

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -231,7 +231,7 @@ extension DiagnosticsController: DeviceStatusDelegate {
             case .authenticated:
                 observabilitySectionStatusLabel.text = "Status: Authenticated"
                 observabilitySectionStatusLabel.textColor = .systemYellow
-            case .streaming(let isTrue):
+            case .online(let isTrue):
                 if isTrue {
                     observabilitySectionStatusLabel.text = "Status: Online"
                     observabilitySectionStatusLabel.textColor = .systemGreen

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDevice.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDevice.swift
@@ -1,6 +1,7 @@
 //
-//  MemfaultDevice.swift
+//  ObservabilityDevice.swift
 //  iOS-nRF-Memfault-Library
+//  iOSOtaLibrary
 //
 //  Created by Dinesh Harjani on 26/8/22.
 //  Copyright © 2025 Nordic Semiconductor ASA. All rights reserved.
@@ -8,7 +9,7 @@
 
 import Foundation
 
-// MARK: - MemfaultDevice
+// MARK: - ObservabilityDevice
 
 struct ObservabilityDevice {
     
@@ -17,7 +18,7 @@ struct ObservabilityDevice {
     let uuidString: String
     var isConnected: Bool
     var isNotifying: Bool
-    var isStreaming: Bool
+    var isOnline: Bool
     var auth: ObservabilityAuth?
     
     // MARK: init
@@ -26,7 +27,7 @@ struct ObservabilityDevice {
         self.uuidString = uuidString
         self.isConnected = false
         self.isNotifying = false
-        self.isStreaming = false
+        self.isOnline = false
         self.auth = nil
     }
 }

--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityDeviceEvent.swift
@@ -17,7 +17,7 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
     
     case connected, disconnected
     
-    case notifications(_ enabled: Bool), streaming(_ enabled: Bool)
+    case notifications(_ enabled: Bool), online(_ isTrue: Bool)
     case authenticated(_ auth: ObservabilityAuth)
     case updatedChunk(_ chunk: ObservabilityChunk)
     
@@ -31,8 +31,8 @@ public enum ObservabilityDeviceEvent: CustomStringConvertible {
             return ".disconnected"
         case .notifications(let enabled):
             return ".notifications(\(enabled ? "enabled" : "disabled"))"
-        case .streaming(let enabled):
-            return ".streaming(\(enabled ? "enabled" : "disabled"))"
+        case .online(let isTrue):
+            return ".online(\(isTrue ? "true" : "false"))"
         case .authenticated(_):
             return ".authenticated(_)"
         case .updatedChunk(let chunk):

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
@@ -83,8 +83,8 @@ internal extension ObservabilityManager {
             try await peripheral.writeValueWithResponse(Data(repeating: 1, count: 1), for: mdsData)
                 .firstValue
             
-            devices[identifier]?.isStreaming = true
-            deviceContinuations[identifier]?.yield((identifier, .streaming(true)))
+            devices[identifier]?.isOnline = true
+            deviceContinuations[identifier]?.yield((identifier, .online(true)))
             
             guard state.pendingChunks(for: identifier).hasItems else { return }
             resumeUploadsIfNotBusy(for: identifier, with: auth)
@@ -112,7 +112,7 @@ internal extension ObservabilityManager {
                 switch completion {
                 case .failure(let error):
                     deviceContinuations[identifier]?.yield((identifier, .notifications(false)))
-                    deviceContinuations[identifier]?.yield((identifier, .streaming(false)))
+                    deviceContinuations[identifier]?.yield((identifier, .online(false)))
                     deviceContinuations[identifier]?.finish(throwing: error)
                     deviceCancellables[identifier]?.removeAll()
                 case .finished:
@@ -228,7 +228,7 @@ extension ObservabilityManager {
                     let updatedChunk = state.update(uploadingChunk, from: identifier, to: .uploadError)
                     deviceContinuations[identifier]?.yield((identifier, .updatedChunk(updatedChunk)))
                     networkBusy = false
-                    deviceContinuations[identifier]?.yield((identifier, .streaming(false)))
+                    deviceContinuations[identifier]?.yield((identifier, .online(false)))
                     enqueueRetryPendingUploads(for: identifier, with: auth)
                 }
             } receiveValue: { [weak self] resultData in

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager.swift
@@ -120,14 +120,14 @@ public extension ObservabilityManager {
         }
         
         do {
-            if device.isStreaming {
+            if device.isOnline {
                 guard let mdsService = peripheral.services?.first(where: { $0.uuid == CBUUID.MDS }),
                       let mdsDataExportCharacteristic = mdsService.characteristics?.first(where: { $0.uuid == CBUUID.MDSDataExportCharacteristic }) else {
                     throw ObservabilityError.mdsDataExportCharacteristicNotFound
                 }
                 _ = try await peripheral.writeValueWithResponse(Data(repeating: 0, count: 1), for: mdsDataExportCharacteristic)
                     .firstValue
-                continuation.yield((identifier, .streaming(false)))
+                continuation.yield((identifier, .online(false)))
             }
             
             if device.isNotifying {


### PR DESCRIPTION
I think this name makes more sense. It meant some form of network / data "streaming". But Online is a lot more readable for everyone.