### PR TITLE
Fix for "bad-MTU" correcting code in McuMgrBleTransport

### DIFF
--- a/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
@@ -177,7 +177,7 @@ public class McuMgrBleTransport: NSObject {
             }
             
             // Note that it is 99.9% likely that this is the wrong value unless
-            // we're already connected. The correct MTU value needs to be in
+            // we're already connected. A valid MTU value needs to be set in
             // the _send() function just after acquiring the (Result)Lock.
             let peripheralWriteValueLength = max(McuManager.ValidMTURange.lowerBound, peripheral.maximumWriteValueLength(for: .withoutResponse))
             return min(peripheralWriteValueLength, defaultMtu)
@@ -404,8 +404,10 @@ extension McuMgrBleTransport: McuMgrTransport {
         
         // Don't be smart caching the MTU.
         let negotiatedMTU = targetPeripheral.maximumWriteValueLength(for: .withoutResponse)
-        if mtu != negotiatedMTU {
-            log(msg: "peripheral.maximumWriteValueLength(for: .withoutResponse): \(negotiatedMTU) != Current MTU (\(mtu))", atLevel: .debug)
+        // It's possible an upper-layer has set a non-max MTU. Either by mistake, or by design.
+        // We only want to force the MTU value to change if the current value causes issues.
+        if mtu > negotiatedMTU {
+            log(msg: "peripheral.maximumWriteValueLength(for: .withoutResponse): \(negotiatedMTU) > Current MTU (\(mtu))", atLevel: .debug)
             mtu = negotiatedMTU
         }
         

--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -500,6 +500,11 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         }
         self.log(msg: "Setting SAR Buffer Size to \(bufferSize) bytes.", atLevel: .verbose)
         self.configuration.reassemblyBufferSize = bufferSize
+        let mtu: Int = self.imageManager.transport.mtu
+        if bufferSize < mtu {
+            self.log(msg: "Parameters SAR Buffer Size (\(bufferSize)) is smaller than negotiated MTU (\(mtu)). Lowering MTU to match.", atLevel: .warning)
+            try? self.setUploadMtu(mtu: Int(bufferSize))
+        }
         self.bootloaderInfo() // Continue to Bootloader Mode.
     }
     


### PR DESCRIPTION
It's possible that the MTU might need to be set lower than maximum. For example (as in testing currently), if the user has a Reassembly Buffer Size smaller than MTU size. This will trip the update code because we will force upper layers to send maximum MTU size packets, when the target device doesn't want to. In theory, MTU should be set to match buffer size, but anyways. I think this was working before, but our speed improvements broke this.