### PR TITLE
Patch for SPM Release

### DIFF
--- a/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NordicPlayground/IOS-Common-Libraries",
       "state" : {
-        "branch" : "13",
-        "revision" : "2b9a131a685aabc59b816241c2d55187203862a2"
+        "revision" : "2b9a131a685aabc59b816241c2d55187203862a2",
+        "version" : "0.1.13"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,10 +24,10 @@ let package = Package(
             .upToNextMajor(from: "0.9.0")
         ),
         .package(url: "https://github.com/NordicSemiconductor/IOS-BLE-Library",
-            .branchItem("main")
+            .upToNextMajor(from: "0.4.3")
         ),
         .package(url: "https://github.com/NordicPlayground/IOS-Common-Libraries",
-            .branchItem("13")
+            .exact("0.1.13")
         )
     ],
     targets: [


### PR DESCRIPTION
Apparently SPM requires releases are pointed to tags, not branches or hashes.