### PR TITLE
Fix for stalled FileSystem uploads when Buffer Size is smaller than MTU

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/FileSystemManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/FileSystemManager.swift
@@ -422,14 +422,7 @@ public class FileSystemManager: McuManager {
             return
         }
         
-        guard let bufferCount = response.bufferCount, var bufferSize = response.bufferSize else {
-            self.log(msg: "Invalid McuMgr Parameters response received.", atLevel: .warning)
-            self.finishedMcuMgrParametersRequest() // Proceed to upload
-            return
-        }
-        self.log(msg: "Mcu Manager parameters received (\(bufferCount) x \(bufferSize))", atLevel: .application)
-        self.storedMcuMgrParametersResponse = response
-        // Continue
+        self.receivedMcuMgrParametersResponse(response)
         self.finishedMcuMgrParametersRequest()
     }
     
@@ -482,7 +475,7 @@ public class FileSystemManager: McuManager {
         if let offset = response.off {
             // if 'first successful sequenceNumber upload'
             if self.offset == 0 && offset > 0, let response = self.storedMcuMgrParametersResponse {
-                self.processMcuMgrParametersResponse(response)
+                self.patchReassemblyAndPipeliningSetup(using: response)
                 self.storedMcuMgrParametersResponse = nil
             }
             // Set the file upload offset.
@@ -612,6 +605,8 @@ public class FileSystemManager: McuManager {
 
 private extension FileSystemManager {
     
+    // MARK: mcuMgrParameters
+    
     func requestMcuMgrParameters() {
         objc_sync_enter(self)
         log(msg: "Requesting McuMgr Parameters...", atLevel: .application)
@@ -622,17 +617,44 @@ private extension FileSystemManager {
         objc_sync_exit(self)
     }
     
-    func processMcuMgrParametersResponse(_ response: McuMgrParametersResponse) {
+    func receivedMcuMgrParametersResponse(_ response: McuMgrParametersResponse) {
         log(msg: "Processing McuMgr Parameters Response.", atLevel: .debug)
-        var bufferSize: UInt64! = response.bufferSize
         guard let bleTransport = transport as? McuMgrBleTransport else {
             log(msg: "Ignoring McuMgr Parameters Response due to unsupported (non-BLE) Transport.", atLevel: .debug)
             return
         }
-        if bufferSize > UInt16.max {
-            bufferSize = UInt64(UInt16.max)
-            log(msg: "SAR Buffer Size is larger than maximum of \(UInt16.max) bytes. Reducing Buffer Size to maximum value.", atLevel: .warning)
+        
+        guard let bufferCount = response.bufferCount, var bufferSize = response.bufferSize else {
+            self.log(msg: "Invalid McuMgr Parameters response received.", atLevel: .warning)
+            storedMcuMgrParametersResponse = nil // just in case
+            return
         }
+        log(msg: "Mcu Manager parameters received (\(bufferCount) x \(bufferSize))", atLevel: .application)
+        storedMcuMgrParametersResponse = response
+        bufferSize = min(response.bufferSize, UInt64(UInt16.max))
+        
+        // Guard against soft-lock on first sequenceNumber upload
+        if bufferSize < transport.mtu {
+            do {
+                log(msg: "SAR Buffer Size of \(bufferSize) is smaller than MTU Size of \(transport.mtu). Setting MTU Size to \(bufferSize).", atLevel: .debug)
+                try setMtu(Int(bufferSize))
+                if bleTransport.chunkSendDataToMtuSize {
+                    log(msg: "Disabling Reassembly due to low Buffer Size of \(bufferSize) bytes.", atLevel: .debug)
+                    bleTransport.chunkSendDataToMtuSize = false
+                }
+            } catch let mtuResetError {
+                cancelTransfer(error: mtuResetError)
+            }
+        }
+    }
+    
+    func patchReassemblyAndPipeliningSetup(using response: McuMgrParametersResponse) {
+        guard let bleTransport = transport as? McuMgrBleTransport else {
+            log(msg: "Skipping \(#function) due to unsupported (non-Bluetooth LE) Transport.", atLevel: .debug)
+            return
+        }
+        
+        var bufferSize: UInt64! = min(response.bufferSize, UInt64(UInt16.max))
         log(msg: "Setting SAR Buffer Size to \(bufferSize) bytes.", atLevel: .debug)
         uploadConfiguration.reassemblyBufferSize = bufferSize
         
@@ -647,17 +669,6 @@ private extension FileSystemManager {
         if bufferSize > bleTransport.mtu, !bleTransport.chunkSendDataToMtuSize {
             log(msg: "Enabling SMP Reassembly.", atLevel: .debug)
             bleTransport.chunkSendDataToMtuSize = true
-        } else if transport.mtu > bufferSize {
-            do {
-                log(msg: "SAR Buffer Size of \(bufferSize) is larger than MTU Size of \(transport.mtu). Setting MTU Size to \(bufferSize).", atLevel: .debug)
-                try setMtu(Int(bufferSize))
-                if bleTransport.chunkSendDataToMtuSize {
-                    log(msg: "Disabling Reassembly due to low Buffer Size of \(bufferSize) bytes.", atLevel: .debug)
-                    bleTransport.chunkSendDataToMtuSize = false
-                }
-            } catch let mtuResetError {
-                cancelTransfer(error: mtuResetError)
-            }
         }
     }
     
@@ -669,12 +680,16 @@ private extension FileSystemManager {
         upload(name: fileName, data: fileData, offset: 0, callback: uploadCallback)
     }
     
+    // MARK: sendNext(from:)
+    
     func sendNext(from offset: UInt) {
         if transferState != .uploading {
             return
         }
         upload(name: fileName!, data: fileData!, offset: offset, callback: uploadCallback)
     }
+    
+    // MARK: requestNext(from:)
     
     func requestNext(from offset: UInt) {
         if transferState != .downloading {


### PR DESCRIPTION
We solved this (again) for DFU, so it was trivial to check for FS, and it turned out it was broken as well, which was surprising because the first thing we checked was the source code, and the source code seemed to account for this scenario, but it was done so after the first packet upload, which is already too late for this particular scenario. We broke it ourselves, if I had to guess.