### PR TITLE
Added safeguards for minimum pipelineDepth value

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/FileSystemManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/FileSystemManager.swift
@@ -201,7 +201,7 @@ public class FileSystemManager: McuManager {
         uploadConfiguration.reassemblyBufferSize = min(uploadConfiguration.reassemblyBufferSize, UInt64(UInt16.max))
         uploadPipeline = McuMgrUploadPipeline(adopting: uploadConfiguration, over: transport)
         if let bleTransport = transport as? McuMgrBleTransport {
-            bleTransport.numberOfParallelWrites = uploadConfiguration.pipelineDepth
+            bleTransport.numberOfParallelWrites = uploadPipeline.depth
             bleTransport.chunkSendDataToMtuSize = uploadConfiguration.reassemblyBufferSize > bleTransport.mtu
         }
         
@@ -660,10 +660,10 @@ private extension FileSystemManager {
         
         if let bufferCount = response.bufferCount, uploadConfiguration.pipelineDepth >= bufferCount {
             log(msg: "Target pipeline depth of \(bufferCount - 1) is smaller than upload configuration of \(uploadConfiguration.pipelineDepth).", atLevel: .warning)
-            log(msg: "Setting pipeline depth to \(bufferCount - 1).", atLevel: .debug)
             uploadConfiguration.pipelineDepth = Int(bufferCount - 1)
             uploadPipeline = McuMgrUploadPipeline(adopting: uploadConfiguration, over: transport)
-            bleTransport.numberOfParallelWrites = uploadConfiguration.pipelineDepth
+            bleTransport.numberOfParallelWrites = uploadPipeline.depth
+            log(msg: "Pipeline depth set to \(uploadPipeline.depth).", atLevel: .debug)
         }
         
         if bufferSize > bleTransport.mtu, !bleTransport.chunkSendDataToMtuSize {

--- a/iOSMcuManagerLibrary/Source/McuMgrUploadPipeline.swift
+++ b/iOSMcuManagerLibrary/Source/McuMgrUploadPipeline.swift
@@ -13,15 +13,16 @@ public struct McuMgrUploadPipeline {
     
     // MARK: Properties
     
+    let depth: Int
+    
     private let bufferSize: UInt64
-    private let depth: Int
     private var lastReceivedOffset: UInt64
     private var expectedReturnOffsets: [UInt64] = []
     
     // MARK: init
     
     public init(adopting configuration: FirmwareUpgradeConfiguration, over transport: McuMgrTransport) {
-        self.depth = configuration.pipelineDepth
+        self.depth = max(1, configuration.pipelineDepth)
         self.bufferSize = configuration.reassemblyBufferSize
         self.lastReceivedOffset = 0
         


### PR DESCRIPTION
This affects both "regular" DFU as well as the FileManager. Essentially, the pipeline depth / number of buffers is a parallel queue of sequence numbers, even though we cannot send them in parallel / interleaved because then the target device cannot make sense of the Data being sent. But, the point is, in a way it sets the number of "tasks" to send or add to a queue in parallel. We were too busy checking we are doing the translation between "number of buffers" and pipeline depth correctly, since UI and the code interpret the same value in different ways (essentially, a -1 arithmetic operation) that we did not bother to check whether the pipelineDepth is set to a value that soft-locks the code... because nothing is sent? If we set the pipeline to zero, then nothing is enqueued to be sent. Essentially freezing everything.

Prompted by: https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/497