### PR TITLE
Refactored FirmwareUpgradeImage into its own file

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeImage.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeImage.swift
@@ -1,0 +1,84 @@
+//
+//  FirmwareUpgradeImage.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 28/11/25.
+//
+
+import Foundation
+
+// MARK: - FirmwareUpgradeImage
+
+internal struct FirmwareUpgradeImage: CustomDebugStringConvertible {
+    
+    // MARK: Properties
+    
+    let image: Int
+    let slot: Int
+    let data: Data
+    let hash: Data
+    let content: McuMgrManifest.File.ContentType
+    var uploaded: Bool
+    var tested: Bool
+    var testSent: Bool
+    var confirmed: Bool
+    var confirmSent: Bool
+    
+    // MARK: Init
+    
+    init(_ image: ImageManager.Image) {
+        self.image = image.image
+        self.slot = image.slot
+        self.data = image.data
+        self.hash = image.hash
+        self.content = image.content
+        self.uploaded = false
+        self.tested = false
+        self.testSent = false
+        self.confirmed = false
+        self.confirmSent = false
+    }
+    
+    // MARK: CustomDebugStringConvertible
+    
+    var debugDescription: String {
+        return """
+        Data: \(data)
+        Hash: \(hash)
+        Image \(image), Slot \(slot), Content \(content.description)
+        Uploaded \(uploaded ? "Yes" : "No")
+        Tested \(tested ? "Yes" : "No"), Test Sent \(testSent ? "Yes" : "No"),
+        Confirmed \(confirmed ? "Yes" : "No"), Confirm Sent \(confirmSent ? "Yes" : "No")
+        """
+    }
+}
+
+// MARK: - Bare Metal
+
+internal extension FirmwareUpgradeImage {
+    
+    func patchForBareMetal() -> Self {
+        return FirmwareUpgradeImage(
+            ImageManager.Image(image: image, slot: 0, content: .bin, hash: hash, data: data)
+        )
+    }
+}
+
+// MARK: - FirmwareUpgradeImage Hashable
+
+extension FirmwareUpgradeImage: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(image)
+        hasher.combine(hash)
+    }
+}
+
+// MARK: - FirmwareUpgradeImage Comparable
+
+extension FirmwareUpgradeImage: Equatable {
+    
+    public static func == (lhs: FirmwareUpgradeImage, rhs: FirmwareUpgradeImage) -> Bool {
+        return lhs.hash == rhs.hash
+    }
+}

--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -1324,7 +1324,7 @@ extension FirmwareUpgradeManager: ImageUploadDelegate {
     }
 }
 
-// MARK: - FirmwareUpgradeManager
+// MARK: - SuitManagerDelegate
 
 extension FirmwareUpgradeManager: SuitManagerDelegate {
     
@@ -1441,80 +1441,4 @@ public protocol SuitFirmwareUpgradeDelegate: FirmwareUpgradeDelegate {
      In SUIT (Software Update for the Internet of Things), various resources, such as specific files, URL contents, etc. may be requested by the firmware device. When it does, this callback will be triggered.
      */
     func uploadRequestsResource(_ resource: FirmwareUpgradeResource)
-}
-
-// MARK: - FirmwareUpgradeImage
-
-internal struct FirmwareUpgradeImage: CustomDebugStringConvertible {
-    
-    // MARK: Properties
-    
-    let image: Int
-    let slot: Int
-    let data: Data
-    let hash: Data
-    let content: McuMgrManifest.File.ContentType
-    var uploaded: Bool
-    var tested: Bool
-    var testSent: Bool
-    var confirmed: Bool
-    var confirmSent: Bool
-    
-    // MARK: Init
-    
-    init(_ image: ImageManager.Image) {
-        self.image = image.image
-        self.slot = image.slot
-        self.data = image.data
-        self.hash = image.hash
-        self.content = image.content
-        self.uploaded = false
-        self.tested = false
-        self.testSent = false
-        self.confirmed = false
-        self.confirmSent = false
-    }
-    
-    // MARK: CustomDebugStringConvertible
-    
-    var debugDescription: String {
-        return """
-        Data: \(data)
-        Hash: \(hash)
-        Image \(image), Slot \(slot), Content \(content.description)
-        Uploaded \(uploaded ? "Yes" : "No")
-        Tested \(tested ? "Yes" : "No"), Test Sent \(testSent ? "Yes" : "No"),
-        Confirmed \(confirmed ? "Yes" : "No"), Confirm Sent \(confirmSent ? "Yes" : "No")
-        """
-    }
-}
-
-// MARK: - Bare Metal
-
-extension FirmwareUpgradeImage {
-    
-    func patchForBareMetal() -> Self {
-        return FirmwareUpgradeImage(
-            ImageManager.Image(image: image, slot: 0, content: .bin, hash: hash, data: data)
-        )
-    }
-}
-
-// MARK: - FirmwareUpgradeImage Hashable
-
-extension FirmwareUpgradeImage: Hashable {
-    
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(image)
-        hasher.combine(hash)
-    }
-}
-
-// MARK: - FirmwareUpgradeImage Comparable
-
-extension FirmwareUpgradeImage: Equatable {
-    
-    public static func == (lhs: FirmwareUpgradeImage, rhs: FirmwareUpgradeImage) -> Bool {
-        return lhs.hash == rhs.hash
-    }
 }


### PR DESCRIPTION
Like, the Manager file was close to 2000 lines? In the early days I just wanted to survive when given tasks to do around here, but at some point we have to clean this up. If only for my own sanity since I have to write more code and make it grow again.