### PR TITLE
Refactored FirmwareUpgradeManager's main Public API functions into their own file

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager+Public.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager+Public.swift
@@ -1,0 +1,153 @@
+//
+//  FirmwareUpgradeManager+Public.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 28/11/25.
+//
+
+import Foundation
+
+// MARK: - FirmwareUpgradeManager Public API
+
+public extension FirmwareUpgradeManager {
+    
+    // MARK: start()
+    
+    /// Start the firmware upgrade.
+    ///
+    /// This is the full-featured API to start DFU update, including support for Multi-Image uploads, DirectXIP, and SUIT. It is a seamless API.
+    /// - parameter package: The (`McrMgrPackage`) to upload.
+    /// - parameter configuration: Fine-tuning of details regarding the upgrade process.
+    public func start(package: McuMgrPackage,
+                      using configuration: FirmwareUpgradeConfiguration = FirmwareUpgradeConfiguration()) {
+        guard package.isForSUIT else {
+            start(images: package.images, using: configuration)
+            return
+        }
+        
+        var suitConfiguration = configuration
+        suitConfiguration.upgradeMode = .uploadOnly
+        // Erase App Settings is not supported by SUIT Bootloader.
+        suitConfiguration.eraseAppSettings = false
+        start(images: package.images, using: suitConfiguration)
+    }
+    
+    /// Start the firmware upgrade.
+    ///
+    /// Use this convenience call of ``start(images:using:)`` if you're only
+    /// updating the App Core (i.e. no Multi-Image).
+    /// - parameter hash: The hash of the Image to be uploaded, used for comparison with the target firmware.
+    /// - parameter data: `Data` to upload to App Core (Image 0).
+    /// - parameter configuration: Fine-tuning of details regarding the upgrade process.
+    @available(*, deprecated, message: "start(package:using:) is now a far more convenient call. Therefore this API is henceforth marked as deprecated and will be removed in a future release.")
+    public func start(hash: Data, data: Data, using configuration: FirmwareUpgradeConfiguration = FirmwareUpgradeConfiguration()) {
+        start(images: [ImageManager.Image(image: 0, hash: hash, data: data)],
+                  using: configuration)
+    }
+    
+    /// Start the firmware upgrade.
+    ///
+    /// This is the full-featured API to start DFU update, including support for Multi-Image uploads.
+    /// - parameter images: An Array of (`ImageManager.Image`) to upload.
+    /// - parameter configuration: Fine-tuning of details regarding the upgrade process.
+    public func start(images: [ImageManager.Image], using configuration: FirmwareUpgradeConfiguration = FirmwareUpgradeConfiguration()) {
+        objc_sync_enter(self)
+        defer {
+            objc_sync_exit(self)
+        }
+        
+        self.imageManager.verifyOnMainThread()
+        guard state == .none else {
+            log(msg: "Firmware upgrade is already in progress", atLevel: .warning)
+            return
+        }
+        
+        self.images = images.map { FirmwareUpgradeImage($0) }
+        self.configuration = configuration
+        self.bootloader = nil
+        
+        // Grab a strong reference to something holding a strong reference to self.
+        cyclicReferenceHolder = { return self }
+        
+        log(msg: "Upgrade started with \(images.count) image(s) using '\(configuration.upgradeMode)' mode",
+            atLevel: .application)
+        delegate?.upgradeDidStart(controller: self)
+        
+        requestMcuMgrParameters()
+    }
+    
+    // MARK: uploadResource(_:data:)
+    
+    /**
+     For SUIT (Software Update for Internet of Things), the target device might request some resource via the ``SuitFirmwareUpgradeDelegate/uploadRequestsResource(_:)`` callback. After that happens, `FirmwareUpgradeManager` will wait until the requested ``FirmwareUpgradeResource`` is provided via this API.
+     
+     - parameter resource: The resource being provided ``FirmwareUpgradeResource``.
+     - parameter data: The bytes of the resource itself.
+     */
+    public func uploadResource(_ resource: FirmwareUpgradeResource, data: Data) {
+        objc_sync_enter(self)
+        suitManager.uploadResource(data)
+        objc_sync_exit(self)
+    }
+    
+    // MARK: cancel()
+    
+    public func cancel() {
+        objc_sync_enter(self)
+        if state == .upload {
+            if bootloader == .suit {
+                suitManager.cancel()
+            } else {
+                imageManager.cancelUpload()
+            }
+            paused = false
+        }
+        objc_sync_exit(self)
+    }
+    
+    // MARK: pause()
+    
+    public func pause() {
+        objc_sync_enter(self)
+        if state.isInProgress() && !paused {
+            paused = true
+            if state == .upload {
+                if bootloader == .suit {
+                    suitManager.pause()
+                } else {
+                    imageManager.pauseUpload()
+                }
+            }
+        }
+        objc_sync_exit(self)
+    }
+    
+    // MARK: resume()
+    
+    public func resume() {
+        objc_sync_enter(self)
+        if paused {
+            paused = false
+            resumeFromCurrentState()
+        }
+        objc_sync_exit(self)
+    }
+    
+    // MARK: isPaused()
+    
+    public func isPaused() -> Bool {
+        return paused
+    }
+    
+    // MARK: isInProgress()
+    
+    public func isInProgress() -> Bool {
+        return state.isInProgress() && !paused
+    }
+    
+    // MARK: setUploadMtu(mtu:)
+    
+    public func setUploadMtu(mtu: Int) throws {
+        try imageManager.setMtu(mtu)
+    }
+}

--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -11,25 +11,25 @@ import CoreBluetooth
 
 public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserver {
     
-    // MARK: Private Properties
+    // MARK: Properties
     
-    private let imageManager: ImageManager
+    internal let imageManager: ImageManager
     private let defaultManager: DefaultManager
     private let basicManager: BasicManager
-    private let suitManager: SuitManager
-    private weak var delegate: FirmwareUpgradeDelegate?
+    internal let suitManager: SuitManager
+    internal weak var delegate: FirmwareUpgradeDelegate?
     
     /// Cyclic reference is used to prevent from releasing the manager
     /// in the middle of an update. The reference cycle will be set
     /// when upgrade was started and released on success, error or cancel.
-    private var cyclicReferenceHolder: (() -> FirmwareUpgradeManager)?
+    internal var cyclicReferenceHolder: (() -> FirmwareUpgradeManager)?
     
-    private var images: [FirmwareUpgradeImage]!
-    private var configuration: FirmwareUpgradeConfiguration!
-    private var bootloader: BootloaderInfoResponse.Bootloader!
+    internal var images: [FirmwareUpgradeImage]!
+    internal var configuration: FirmwareUpgradeConfiguration!
+    internal var bootloader: BootloaderInfoResponse.Bootloader!
     
-    private var state: FirmwareUpgradeState
-    private var paused: Bool
+    internal var state: FirmwareUpgradeState
+    internal var paused: Bool
     
     /// Logger delegate may be used to obtain logs.
     public weak var logDelegate: McuMgrLogDelegate? {
@@ -42,7 +42,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     
     private var resetResponseTime: Date?
     
-    // MARK: Init
+    // MARK: init
     
     public init(transport: McuMgrTransport, delegate: FirmwareUpgradeDelegate?) {
         self.imageManager = ImageManager(transport: transport)
@@ -52,132 +52,6 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         self.delegate = delegate
         self.state = .none
         self.paused = false
-    }
-    
-    // MARK: start(package:using:)
-    
-    /// Start the firmware upgrade.
-    ///
-    /// This is the full-featured API to start DFU update, including support for Multi-Image uploads, DirectXIP, and SUIT. It is a seamless API.
-    /// - parameter package: The (`McrMgrPackage`) to upload.
-    /// - parameter configuration: Fine-tuning of details regarding the upgrade process.
-    public func start(package: McuMgrPackage,
-                      using configuration: FirmwareUpgradeConfiguration = FirmwareUpgradeConfiguration()) {
-        guard package.isForSUIT else {
-            start(images: package.images, using: configuration)
-            return
-        }
-        
-        var suitConfiguration = configuration
-        suitConfiguration.upgradeMode = .uploadOnly
-        // Erase App Settings is not supported by SUIT Bootloader.
-        suitConfiguration.eraseAppSettings = false
-        start(images: package.images, using: suitConfiguration)
-    }
-    
-    /// Start the firmware upgrade.
-    ///
-    /// Use this convenience call of ``start(images:using:)`` if you're only
-    /// updating the App Core (i.e. no Multi-Image).
-    /// - parameter hash: The hash of the Image to be uploaded, used for comparison with the target firmware.
-    /// - parameter data: `Data` to upload to App Core (Image 0).
-    /// - parameter configuration: Fine-tuning of details regarding the upgrade process.
-    @available(*, deprecated, message: "start(package:using:) is now a far more convenient call. Therefore this API is henceforth marked as deprecated and will be removed in a future release.")
-    public func start(hash: Data, data: Data, using configuration: FirmwareUpgradeConfiguration = FirmwareUpgradeConfiguration()) {
-        start(images: [ImageManager.Image(image: 0, hash: hash, data: data)],
-                  using: configuration)
-    }
-    
-    /// Start the firmware upgrade.
-    ///
-    /// This is the full-featured API to start DFU update, including support for Multi-Image uploads.
-    /// - parameter images: An Array of (`ImageManager.Image`) to upload.
-    /// - parameter configuration: Fine-tuning of details regarding the upgrade process.
-    public func start(images: [ImageManager.Image], using configuration: FirmwareUpgradeConfiguration = FirmwareUpgradeConfiguration()) {
-        objc_sync_enter(self)
-        defer {
-            objc_sync_exit(self)
-        }
-        
-        self.imageManager.verifyOnMainThread()
-        guard state == .none else {
-            log(msg: "Firmware upgrade is already in progress", atLevel: .warning)
-            return
-        }
-        
-        self.images = images.map { FirmwareUpgradeImage($0) }
-        self.configuration = configuration
-        self.bootloader = nil
-        
-        // Grab a strong reference to something holding a strong reference to self.
-        cyclicReferenceHolder = { return self }
-        
-        log(msg: "Upgrade started with \(images.count) image(s) using '\(configuration.upgradeMode)' mode",
-            atLevel: .application)
-        delegate?.upgradeDidStart(controller: self)
-        
-        requestMcuMgrParameters()
-    }
-    
-    /**
-     For SUIT (Software Update for Internet of Things), the target device might request some resource via the ``SuitFirmwareUpgradeDelegate/uploadRequestsResource(_:)`` callback. After that happens, `FirmwareUpgradeManager` will wait until the requested ``FirmwareUpgradeResource`` is provided via this API.
-     
-     - parameter resource: The resource being provided ``FirmwareUpgradeResource``.
-     - parameter data: The bytes of the resource itself.
-     */
-    public func uploadResource(_ resource: FirmwareUpgradeResource, data: Data) {
-        objc_sync_enter(self)
-        suitManager.uploadResource(data)
-        objc_sync_exit(self)
-    }
-    
-    public func cancel() {
-        objc_sync_enter(self)
-        if state == .upload {
-            if bootloader == .suit {
-                suitManager.cancel()
-            } else {
-                imageManager.cancelUpload()
-            }
-            paused = false
-        }
-        objc_sync_exit(self)
-    }
-    
-    public func pause() {
-        objc_sync_enter(self)
-        if state.isInProgress() && !paused {
-            paused = true
-            if state == .upload {
-                if bootloader == .suit {
-                    suitManager.pause()
-                } else {
-                    imageManager.pauseUpload()
-                }
-            }
-        }
-        objc_sync_exit(self)
-    }
-    
-    public func resume() {
-        objc_sync_enter(self)
-        if paused {
-            paused = false
-            resumeFromCurrentState()
-        }
-        objc_sync_exit(self)
-    }
-    
-    public func isPaused() -> Bool {
-        return paused
-    }
-    
-    public func isInProgress() -> Bool {
-        return state.isInProgress() && !paused
-    }
-    
-    public func setUploadMtu(mtu: Int) throws {
-        try imageManager.setMtu(mtu)
     }
     
     //**************************************************************************
@@ -196,7 +70,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         objc_sync_exit(self)
     }
     
-    private func requestMcuMgrParameters() {
+    internal func requestMcuMgrParameters() {
         objc_sync_setState(.requestMcuMgrParameters)
         if !paused {
             log(msg: "Requesting McuMgr Parameters...", atLevel: .verbose)
@@ -428,7 +302,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
         }
     }
     
-    private func resumeFromCurrentState() {
+    internal func resumeFromCurrentState() {
         objc_sync_enter(self)
         defer {
             objc_sync_exit(self)
@@ -1143,7 +1017,7 @@ public class FirmwareUpgradeManager: FirmwareUpgradeController, ConnectionObserv
     }
 }
 
-private extension FirmwareUpgradeManager {
+internal extension FirmwareUpgradeManager {
     
     func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
         if let logDelegate, level >= logDelegate.minLogLevel() {


### PR DESCRIPTION
As well as helping improve the overall size of the main file, it's helpful for users of this library to figure out what are the main calls they should be interacting with.