### PR TITLE
Buttonless DFU for NCS Bare Metal

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -423,6 +423,8 @@ extension FirmwareUpgradeViewController: FirmwareUpgradeDelegate {
         switch newState {
         case .none:
             status.text = ""
+        case .resetIntoFirmwareLoader:
+            status.text = "RESETTING INTO FW LOADER MODE..."
         case .requestMcuMgrParameters:
             status.text = "REQUESTING MCUMGR PARAMETERS..."
         case .bootloaderInfo:

--- a/Example/Example/View Controllers/Manager/ResetViewController.swift
+++ b/Example/Example/View Controllers/Manager/ResetViewController.swift
@@ -61,7 +61,7 @@ final class ResetViewController: UIViewController, McuMgrViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         firmwareLoaderToggleChanged(switchToFirmwareLoaderToggle)
         
-        advertisingNameTextField.placeholder = "Defaults to 'Unnamed-[HH]-[mm]'"
+        advertisingNameTextField.placeholder = "Defaults to 'fl_[HH]_[mm]'"
     }
     
     // MARK: callReset(mode:)
@@ -76,7 +76,7 @@ final class ResetViewController: UIViewController, McuMgrViewController {
         }
         
         let name: String! = (advertisingNameTextField.text?.hasItems ?? false) ?
-            advertisingNameTextField.text : fallbackAdvertisingName()
+            advertisingNameTextField.text : settingsManager.generateNewAdvertisingName()
         settingsManager.setFirmwareLoaderAdvertisingName(name) { [unowned self] response, error in
             guard error == nil else {
                 resetAction.isEnabled = true
@@ -87,17 +87,5 @@ final class ResetViewController: UIViewController, McuMgrViewController {
                 resetAction.isEnabled = true
             }
         }
-    }
-    
-    private func fallbackAdvertisingName() -> String {
-        let now: Date
-        if #available(iOS 15, *) {
-            now = .now
-        } else {
-            now = Date()
-        }
-        
-        let components = Calendar.current.dateComponents([.hour, .minute], from: now)
-        return "Unnamed-\(components.hour!)-\(components.minute!)"
     }
 }

--- a/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
+++ b/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport+CBCentralManagerDelegate.swift
@@ -18,7 +18,8 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
             if let peripheral = centralManager
                 .retrievePeripherals(withIdentifiers: [identifier])
                 .first {
-                self.peripheral = peripheral
+                log(msg: "\(#function): Setting Peripheral for \(mode) mode.", atLevel: .debug)
+                modePeripherals[mode] = peripheral
                 connectionLock.open(key: McuMgrBleTransportKey.awaitingCentralManager.rawValue)
             } else {
                 connectionLock.open(McuMgrBleTransportError.centralManagerNotReady)
@@ -44,10 +45,7 @@ extension McuMgrBleTransport: CBCentralManagerDelegate {
             return
         }
         log(msg: "Peripheral disconnected", atLevel: .info)
-        peripheral.delegate = nil
-        smpCharacteristic = nil
-        connectionLock.open(McuMgrTransportError.disconnected)
-        state = .disconnected
+        didDisconnect()
         notifyStateChanged(.disconnected)
     }
     

--- a/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
@@ -36,8 +36,6 @@ public protocol PeripheralDelegate: AnyObject {
 
 public class McuMgrBleTransport: NSObject {
     
-    /// The CBPeripheral for this transport to communicate with.
-    internal var peripheral: CBPeripheral?
     /// The CBCentralManager instance from which the peripheral was obtained.
     /// This is used to connect and cancel connection.
     internal let centralManager: CBCentralManager
@@ -56,6 +54,11 @@ public class McuMgrBleTransport: NSObject {
     
     internal let configuration: McuMgrBleTransport.Configuration
     
+    /// There's no longer a @peripheral property. Instead, since we had to add
+    /// the modes, we store ``CBPeripheral``s in a dictionary we query based
+    /// on the current ``mode``.
+    internal var modePeripherals: [McuMgrTransportMode: CBPeripheral]
+    
     /// SMP Characteristic object. Used to write requests and receive
     /// notifications.
     internal var smpCharacteristic: CBCharacteristic?
@@ -65,6 +68,16 @@ public class McuMgrBleTransport: NSObject {
             log(msg: "MTU set to \(mtu)", atLevel: .info)
         }
     }
+    
+    /// Mode of operation.
+    ///
+    /// In the case of ``McuMgrBleTransport``, we've hijacked
+    /// it to represent targeted ``CBPeripheral``. This is because for resets into
+    /// Firmware Loader mode, the same physical device is represented by a different
+    /// ``CBPeripheral``. Since the ``McuMgrTransport`` handles transport, we had
+    /// to extend the API in some way, whilst trying to keep it flexible for other
+    /// methods of transport. As well as to attempt to provide some semblance of consistency.
+    public private(set) var mode: McuMgrTransportMode
     
     /// An array of observers.
     private var observers: [ConnectionObserver]
@@ -165,10 +178,14 @@ public class McuMgrBleTransport: NSObject {
         self.operationQueue.qualityOfService = .userInitiated
         self.operationQueue.maxConcurrentOperationCount = 1
         self.configuration = configuration
+        self.mode = .default
+        self.modePeripherals = [:]
         super.init()
 
         self.centralManager.delegate = self
-        self.peripheral = peripheral
+        if let peripheral {
+            modePeripherals[mode] = peripheral
+        }
         
         self.mtu = {
             let defaultMtu = McuManager.getDefaultMtu(scheme: getScheme())
@@ -185,7 +202,7 @@ public class McuMgrBleTransport: NSObject {
     }
     
     public var name: String? {
-        return peripheral?.name
+        return modePeripherals[mode]?.name
     }
     
     public private(set) var identifier: UUID
@@ -193,7 +210,7 @@ public class McuMgrBleTransport: NSObject {
     // MARK: notifyPeripheralDelegate
     
     private func notifyPeripheralDelegate() {
-        guard let delegate, let peripheral else { return }
+        guard let delegate, let peripheral = modePeripherals[mode] else { return }
         delegate.peripheral(peripheral, didChangeStateTo: state)
     }
 }
@@ -204,6 +221,29 @@ extension McuMgrBleTransport: McuMgrTransport {
     
     public func getScheme() -> McuMgrScheme {
         return .ble
+    }
+    
+    public func switchMode(to newMode: McuMgrTransportMode, with modeParameter: Any?) throws {
+        guard mode != newMode else {
+            throw McuMgrBleTransportError.alreadyInRequestedMode
+        }
+        
+        guard modePeripherals[mode]?.state == .disconnected else {
+            throw McuMgrBleTransportError.modeSwitchRequestedWithPeripheralStillConnected
+        }
+        
+        didDisconnect()
+        softReset()
+        if let modePeripheral = modeParameter as? CBPeripheral {
+            modePeripherals[newMode] = modePeripheral
+        }
+        
+        guard let newPeripheral = modePeripherals[newMode] else {
+            throw McuMgrBleTransportError.modeSwitchRequestedWithoutPeripheral
+        }
+        mode = newMode
+        identifier = newPeripheral.identifier
+        log(msg: "Successfully switched to \(mode) mode.", atLevel: .debug)
     }
     
     public func send<T: McuMgrResponse>(data: Data, timeout: Int, callback: @escaping McuMgrCallback<T>) {
@@ -258,7 +298,8 @@ extension McuMgrBleTransport: McuMgrTransport {
     }
     
     public func close() {
-        if let peripheral, peripheral.state == .connected || peripheral.state == .connecting {
+        if let peripheral = modePeripherals[mode],
+           peripheral.state == .connected || peripheral.state == .connecting {
             log(msg: "Cancelling connection...", atLevel: .verbose)
             state = .disconnecting
             centralManager.cancelPeripheralConnection(peripheral)
@@ -296,6 +337,13 @@ extension McuMgrBleTransport: McuMgrTransport {
         robWriteBuffer = McuMgrBleROBWriteBuffer(logDelegate)
     }
     
+    internal func didDisconnect() {
+        modePeripherals[mode]?.delegate = nil
+        smpCharacteristic = nil
+        connectionLock.open(McuMgrTransportError.disconnected)
+        state = .disconnected
+    }
+    
     /// This method sends the data to the target. Before, it ensures that
     /// CBCentralManager is ready and the peripheral is connected.
     /// The peripheral will automatically be connected when it's not.
@@ -311,7 +359,7 @@ extension McuMgrBleTransport: McuMgrTransport {
         // Wait until it is ready, and timeout if we do not get a valid peripheral instance
         let targetPeripheral: CBPeripheral
 
-        if let existing = peripheral, centralManager.state == .poweredOn {
+        if let existing = modePeripherals[mode], centralManager.state == .poweredOn {
             targetPeripheral = existing
         } else {
             connectionLock.close(key: McuMgrBleTransportKey.awaitingCentralManager.rawValue)
@@ -323,7 +371,7 @@ extension McuMgrBleTransport: McuMgrTransport {
             case let .failure(error):
                 return .failure(error)
             case .success:
-                guard let target = self.peripheral else {
+                guard let target = modePeripherals[mode] else {
                     return .failure(McuMgrTransportError.connectionTimeout)
                 }
                 // continue
@@ -513,6 +561,9 @@ public enum McuMgrBleTransportError: Error, LocalizedError {
     case missingService
     case missingCharacteristic
     case missingNotifyProperty
+    case alreadyInRequestedMode
+    case modeSwitchRequestedWithPeripheralStillConnected
+    case modeSwitchRequestedWithoutPeripheral
     
     public var errorDescription: String? {
         switch self {
@@ -526,6 +577,12 @@ public enum McuMgrBleTransportError: Error, LocalizedError {
             return "SMP characteristic not found."
         case .missingNotifyProperty:
             return "SMP characteristic does not have notify property."
+        case .alreadyInRequestedMode:
+            return "Cannot change mode since transport is already in the requested mode."
+        case .modeSwitchRequestedWithPeripheralStillConnected :
+            return "Cannot switch mode (CBPeripheral) when the previous mode (CBPeripheral) is still connected to this transport."
+        case .modeSwitchRequestedWithoutPeripheral:
+            return "There's no CBPeripheral attached to the requested mode switch."
         }
     }
 }

--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradePeripheralFinder.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradePeripheralFinder.swift
@@ -1,0 +1,86 @@
+//
+//  FirmwareUpgradePeripheralFinder.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 1/12/25.
+//
+
+import Foundation
+import CoreBluetooth
+
+// MARK: - FirmwareUpgradePeripheralFinder
+
+final class FirmwareUpgradePeripheralFinder: NSObject {
+    
+    private static let Timeout: TimeInterval = 15.0
+    
+    // MARK: Private Properties
+    
+    private weak var centralManager: CBCentralManager?
+    
+    typealias FindCallback = (Result<CBPeripheral, FirmwareUpgradeManagerPeripheralFinderError>) -> Void
+    private var searchCallback: FindCallback?
+    private var safeguardedDelegate: (any CBCentralManagerDelegate)?
+    private var searchName: String
+    
+    // MARK: init
+    
+    init(_ centralManager: CBCentralManager, searchName: String) {
+        self.centralManager = centralManager
+        self.searchName = searchName
+    }
+    
+    // MARK: API
+    
+    func find(with callback: @escaping FindCallback) {
+        safeguardedDelegate = centralManager?.delegate
+        searchCallback = callback
+        centralManager?.delegate = self
+        centralManager?.scanForPeripherals(withServices: nil, options: [
+            CBAdvertisementDataLocalNameKey: searchName
+        ])
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.Timeout) { [weak self] in
+            guard let self, let centralManager, let safeguardedDelegate,
+                                let searchCallback, centralManager.isScanning else { return }
+            // If we're still alive and Central Manager has not stopped scanning,
+            // most likely this is a timeout scenario.
+            centralManager.stopScan()
+            centralManager.delegate = safeguardedDelegate
+            searchCallback(.failure(.timeout))
+        }
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension FirmwareUpgradePeripheralFinder: CBCentralManagerDelegate {
+    
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        let peripheralName = peripheral.name ?? ""
+        let advertisedName = (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? ""
+        
+        guard peripheralName.localizedCaseInsensitiveContains(searchName)
+                || advertisedName.localizedCaseInsensitiveContains(searchName) else { return }
+        centralManager?.stopScan()
+        centralManager?.delegate = safeguardedDelegate
+        searchCallback?(.success(peripheral))
+    }
+    
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        // No-op.
+    }
+}
+
+// MARK: - Error
+
+enum FirmwareUpgradeManagerPeripheralFinderError: LocalizedError {
+    case timeout
+    
+    var errorDescription: String? {
+        switch self {
+        case .timeout:
+            return "Failed due to timeout: unable to find device in a reasonable time."
+        }
+    }
+}

--- a/iOSMcuManagerLibrary/Source/Managers/SettingsManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/SettingsManager.swift
@@ -100,6 +100,23 @@ public class SettingsManager: McuManager {
     }
 }
 
+// MARK: - API
+
+public extension SettingsManager {
+    
+    func generateNewAdvertisingName() -> String {
+        let now: Date
+        if #available(iOS 15, *) {
+            now = .now
+        } else {
+            now = Date()
+        }
+        
+        let components = Calendar.current.dateComponents([.hour, .minute, .second], from: now)
+        return "FL_\(components.hour!)\(components.minute!)\(components.second!)"
+    }
+}
+
 // MARK: - SettingsManagerError
 
 public enum SettingsManagerError: UInt64, Error, LocalizedError {

--- a/iOSMcuManagerLibrary/Source/McuMgrTransport.swift
+++ b/iOSMcuManagerLibrary/Source/McuMgrTransport.swift
@@ -7,6 +7,8 @@
 import Foundation
 import CoreBluetooth
 
+// MARK: - McuMgrScheme
+
 /// McuManager transport scheme.
 public enum McuMgrScheme {
     case ble, coapBle, coapUdp
@@ -20,9 +22,13 @@ public enum McuMgrScheme {
     }
 }
 
+// MARK: - McuMgrTransportState
+
 public enum McuMgrTransportState {
     case connected, disconnected
 }
+
+// MARK: - ConnectionObserver
 
 /// The connection state observer protocol.
 public protocol ConnectionObserver: AnyObject {
@@ -33,13 +39,19 @@ public protocol ConnectionObserver: AnyObject {
     func transport(_ transport: McuMgrTransport, didChangeStateTo state: McuMgrTransportState)
 }
 
+// MARK: - ConnectionResult
+
 public enum ConnectionResult {
     case connected
     case deferred
     case failed(Error)
 }
 
+// MARK: - ConnectionCallback
+
 public typealias ConnectionCallback = (ConnectionResult) -> Void
+
+// MARK: - McuMgrTransportError
 
 public enum McuMgrTransportError: Error, Hashable {
     /// Connection to the remote device has timed out.
@@ -67,6 +79,8 @@ public enum McuMgrTransportError: Error, Hashable {
     /// Device BLE Radio not ready to accept more writes.
     case peripheralNotReadyForWriteWithoutResponse
 }
+
+// MARK: - LocalizedError
 
 extension McuMgrTransportError: LocalizedError {
     
@@ -98,6 +112,8 @@ extension McuMgrTransportError: LocalizedError {
     }
 }
 
+// MARK: - McuMgrTransport
+
 /// Mcu Mgr transport object. The transport object
 /// should automatically handle connection on first request.
 public protocol McuMgrTransport: AnyObject {
@@ -109,10 +125,14 @@ public protocol McuMgrTransport: AnyObject {
      */
     var mtu: Int! { get set }
     
+    var mode: McuMgrTransportMode { get }
+    
     /// Returns the transport scheme.
     ///
     /// - returns: The transport scheme.
     func getScheme() -> McuMgrScheme
+    
+    func switchMode(to newMode: McuMgrTransportMode, with modeParameter: Any?) throws
     
     /// Sends given data using the transport object.
     ///
@@ -136,4 +156,20 @@ public protocol McuMgrTransport: AnyObject {
     ///
     /// - parameter observer: The observer to be removed.
     func removeObserver(_ observer: ConnectionObserver);
+}
+
+// MARK: - McuMgrTransportMode
+
+public enum McuMgrTransportMode: CustomStringConvertible {
+    case `default`
+    case alternate
+    
+    public var description: String {
+        switch self {
+        case .default:
+            return "default"
+        case .alternate:
+            return "alternate"
+        }
+    }
 }


### PR DESCRIPTION
Added the concept of "modes" to McuMgrTransport, which is a bit... I tried, or did my best, to not add any hacks. The transport takes care of the peripheral, and it still does. We just tried to add the capability for the same transport to talk to different peripherals, although in practice it's the same device. This is the less hacky way we could find. The transport also has never been the one with the responsibility yo "find" a device, so we added a new helper type to FirmwareUpgradeManager to handle that.

Note that this implementation targets sample code that is subject to change with no prior warning.