### PR TITLE
No #available use because... xcodebuild or cocoapods is blind

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/SettingsManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/SettingsManager.swift
@@ -105,14 +105,9 @@ public class SettingsManager: McuManager {
 public extension SettingsManager {
     
     func generateNewAdvertisingName() -> String {
-        let now: Date
-        if #available(iOS 15, macCatalyst 15.0, macOS 12.0, *) {
-            now = .now
-        } else {
-            now = Date()
-        }
-        
-        let components = Calendar.current.dateComponents([.hour, .minute, .second], from: now)
+        let now = Date()
+        let components = Calendar.current.dateComponents([.hour, .minute, .second],
+                                                         from: now)
         return "FL_\(components.hour!)\(components.minute!)\(components.second!)"
     }
 }


### PR DESCRIPTION
Sacrifices or compromises. Whatever you want to call it.