### PR TITLE
401 Network Code Detection

### DIFF
--- a/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
+++ b/Example/Example/View Controllers/Manager/FirmwareUpgradeViewController.swift
@@ -225,6 +225,8 @@ final class FirmwareUpgradeViewController: UIViewController, McuMgrViewControlle
             let alertController = UIAlertController(title: "Network Error", message: "Unable to reach the Network.", preferredStyle: .alert)
             baseController?.present(alertController, addingCancelAction: true,
                                     cancelActionTitle: "OK")
+        case .invalidProjectKey(let deviceInfo):
+            setProjectKey(for: deviceInfo)
         case .deviceIsUpToDate:
             let alertController = UIAlertController(title: "Your device is up to date", message: "Your device is already using the latest firmware version available through nRF Cloud OTA.", preferredStyle: .alert)
             baseController?.present(alertController, addingCancelAction: true,

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -140,7 +140,11 @@ public extension OTAManager {
             }
             return releaseInfo
         } catch let networkError as URLError {
-            throw OTAManagerError.networkError
+            if networkError.code == .userAuthenticationRequired {
+                throw OTAManagerError.invalidProjectKey(deviceInfo)
+            } else {
+                throw OTAManagerError.networkError
+            }
         } catch {
             throw error
         }
@@ -218,6 +222,7 @@ public enum OTAManagerError: LocalizedError {
     case mdsKeyDecodeError
     case unableToParseResponse
     case networkError
+    case invalidProjectKey(_ deviceInfo: DeviceInfoToken)
     case deviceIsUpToDate
     case invalidArtifactURL
     case sha256HashMismatch


### PR DESCRIPTION
On 401 for Release Info, we instead offer the customer the option of typing in the Project Key. Although we're doing it in a very lazy way, I have to admit.