### PR TITLE
Async Rewrite of MemfaultManager

### DIFF
--- a/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
+++ b/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
@@ -32,20 +32,28 @@ public class MemfaultManager: McuManager {
     
     // MARK: readDeviceInfo
     
-    public func readDeviceInfo(callback: @escaping McuMgrCallback<MemfaultDeviceInfoResponse>) {
-        read(.deviceInfo, callback: callback)
+    public func readDeviceInfo() async throws -> MemfaultDeviceInfoResponse? {
+        try await asyncRead(.deviceInfo)
     }
     
     // MARK: readProjectKey
     
-    public func readProjectKey(callback: @escaping McuMgrCallback<MemfaultProjectKeyResponse>) {
-        read(.projectKey, callback: callback)
+    public func readProjectKey() async throws -> MemfaultProjectKeyResponse? {
+        try await asyncRead(.projectKey)
     }
     
     // MARK: Private
     
-    private func read<R: McuMgrResponse>(_ command: CommandID, callback: @escaping McuMgrCallback<R>) {
-        send(op: .read, commandId: command, payload: nil, callback: callback)
+    private func asyncRead<R: McuMgrResponse>(_ command: CommandID) async throws -> R? {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<R?, Error>) in
+            let callback: McuMgrCallback<R> = { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                }
+                continuation.resume(returning: response)
+            }
+            send(op: .read, commandId: command, payload: nil, callback: callback)
+        }
     }
 }
 

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -46,20 +46,15 @@ public extension OTAManager {
         }
         memfaultManager = MemfaultManager(transport: transport)
         
-        let token = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<DeviceInfoToken, Error>) in
-            memfaultManager?.readDeviceInfo { [unowned self] response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let response, let token = response.deviceToken() else {
-                    continuation.resume(throwing: OTAManagerError.unableToParseResponse)
-                    return
-                }
-                continuation.resume(returning: token)
+        do {
+            guard let deviceInfo = try await memfaultManager?.readDeviceInfo(),
+                  let token = deviceInfo.deviceToken() else {
+                throw OTAManagerError.unableToParseResponse
             }
+            return token
+        } catch {
+            throw error
         }
-        return token
     }
     
     // MARK: getProjectKey
@@ -70,20 +65,15 @@ public extension OTAManager {
         }
         memfaultManager = MemfaultManager(transport: transport)
         
-        let key = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ProjectKey, Error>) in
-            memfaultManager?.readProjectKey { [unowned self] response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let response, let token = response.projectKey() else {
-                    continuation.resume(throwing: OTAManagerError.unableToParseResponse)
-                    return
-                }
-                continuation.resume(returning: token)
+        do {
+            guard let deviceInfo = try await memfaultManager?.readProjectKey(),
+                  let projectKey = deviceInfo.projectKey() else {
+                throw OTAManagerError.unableToParseResponse
             }
+            return projectKey
+        } catch {
+            throw error
         }
-        return key
     }
     
     // MARK: Release Info


### PR DESCRIPTION
Previously the async code was in OTAManager. Now it's in the MemfaultManager itself, as a sort of test run to bring McuManager closer to the async await paradigm.