### PR TITLE
Improved logging for new MemfaultManager

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -313,6 +313,7 @@ private extension BaseViewController {
         guard let otaManager else {
             throw ObservabilityError.mdsServiceNotFound
         }
+        otaManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
         let deviceInfo = try await otaManager.getDeviceInfoToken(via: transport)
         let projectKey = try await otaManager.getProjectKey(via: transport)
         return (deviceInfo, projectKey)

--- a/iOSMcuManagerLibrary/Source/McuManager.swift
+++ b/iOSMcuManagerLibrary/Source/McuManager.swift
@@ -314,7 +314,7 @@ open class McuManager: NSObject {
 
 // MARK: log(msg: atLevel:)
 
-extension McuManager {
+public extension McuManager {
     
     func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
         if let logDelegate, level >= logDelegate.minLogLevel() {

--- a/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
+++ b/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
@@ -33,13 +33,25 @@ public class MemfaultManager: McuManager {
     // MARK: readDeviceInfo
     
     public func readDeviceInfo() async throws -> MemfaultDeviceInfoResponse? {
-        try await asyncRead(.deviceInfo)
+        do {
+            log(msg: "Attempting to read Device Information from Memfault Group...", atLevel: .debug)
+            return try await asyncRead(.deviceInfo)
+        } catch {
+            log(msg: "Error reading Device Information: \(error.localizedDescription)", atLevel: .error)
+            throw error
+        }
     }
     
     // MARK: readProjectKey
     
     public func readProjectKey() async throws -> MemfaultProjectKeyResponse? {
-        try await asyncRead(.projectKey)
+        do {
+            log(msg: "Attempting to read Project Key from Memfault Group...", atLevel: .debug)
+            return try await asyncRead(.projectKey)
+        } catch {
+            log(msg: "Error reading Project Key: \(error.localizedDescription)", atLevel: .error)
+            throw error
+        }
     }
     
     // MARK: Private

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -21,16 +21,21 @@ public final class OTAManager {
     private let network: Network
     private var memfaultManager: MemfaultManager?
     
+    // MARK: Properties
+    
+    public weak var logDelegate: (any McuMgrLogDelegate)?
+    
     // MARK: init
     
     public init() {
-        self.network = Network("api.memfault.com")
+        network = Network("api.memfault.com")
     }
     
     // MARK: deinit
     
     deinit {
         print(#function)
+        logDelegate = nil
     }
 }
 
@@ -45,7 +50,7 @@ public extension OTAManager {
             memfaultManager = nil
         }
         memfaultManager = MemfaultManager(transport: transport)
-        
+        memfaultManager?.logDelegate = logDelegate
         do {
             guard let deviceInfo = try await memfaultManager?.readDeviceInfo(),
                   let token = deviceInfo.deviceToken() else {
@@ -64,7 +69,7 @@ public extension OTAManager {
             memfaultManager = nil
         }
         memfaultManager = MemfaultManager(transport: transport)
-        
+        memfaultManager?.logDelegate = logDelegate
         do {
             guard let deviceInfo = try await memfaultManager?.readProjectKey(),
                   let projectKey = deviceInfo.projectKey() else {


### PR DESCRIPTION
It's a bit tricky with the nRFCDM implementation with the chain of logDelegate(s) being passed down, which it's all the same thing, since the only delegate is the UIApplication.