### PR TITLE
Better Error Logging for Memfault Group

### DIFF
--- a/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
+++ b/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
@@ -32,10 +32,17 @@ public class MemfaultManager: McuManager {
     
     // MARK: readDeviceInfo
     
-    public func readDeviceInfo() async throws -> MemfaultDeviceInfoResponse? {
+    public func readDeviceInfo() async throws -> DeviceInfoToken {
         do {
             log(msg: "Attempting to read Device Information from Memfault Group...", atLevel: .debug)
-            return try await asyncRead(.deviceInfo)
+            let response: MemfaultDeviceInfoResponse? = try await asyncRead(.deviceInfo)
+            if let error = response?.getError() {
+                throw error
+            }
+            guard let token = response?.deviceToken() else {
+                throw OTAManagerError.unableToParseResponse
+            }
+            return token
         } catch {
             log(msg: "Error reading Device Information: \(error.localizedDescription)", atLevel: .error)
             throw error
@@ -44,10 +51,17 @@ public class MemfaultManager: McuManager {
     
     // MARK: readProjectKey
     
-    public func readProjectKey() async throws -> MemfaultProjectKeyResponse? {
+    public func readProjectKey() async throws -> ProjectKey {
         do {
             log(msg: "Attempting to read Project Key from Memfault Group...", atLevel: .debug)
-            return try await asyncRead(.projectKey)
+            let response: MemfaultProjectKeyResponse? = try await asyncRead(.projectKey)
+            if let error = response?.getError() {
+                throw error
+            }
+            guard let projectKey = response?.projectKey() else {
+                throw OTAManagerError.unableToParseResponse
+            }
+            return projectKey
         } catch {
             log(msg: "Error reading Project Key: \(error.localizedDescription)", atLevel: .error)
             throw error

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -49,14 +49,12 @@ public extension OTAManager {
         if memfaultManager != nil {
             memfaultManager = nil
         }
-        memfaultManager = MemfaultManager(transport: transport)
-        memfaultManager?.logDelegate = logDelegate
+        
         do {
-            guard let deviceInfo = try await memfaultManager?.readDeviceInfo(),
-                  let token = deviceInfo.deviceToken() else {
-                throw OTAManagerError.unableToParseResponse
-            }
-            return token
+            let manager = MemfaultManager(transport: transport)
+            memfaultManager = manager
+            memfaultManager?.logDelegate = logDelegate
+            return try await manager.readDeviceInfo()
         } catch {
             throw error
         }
@@ -68,14 +66,12 @@ public extension OTAManager {
         if memfaultManager != nil {
             memfaultManager = nil
         }
-        memfaultManager = MemfaultManager(transport: transport)
-        memfaultManager?.logDelegate = logDelegate
+        
         do {
-            guard let deviceInfo = try await memfaultManager?.readProjectKey(),
-                  let projectKey = deviceInfo.projectKey() else {
-                throw OTAManagerError.unableToParseResponse
-            }
-            return projectKey
+            let manager = MemfaultManager(transport: transport)
+            memfaultManager = manager
+            memfaultManager?.logDelegate = logDelegate
+            return try await manager.readProjectKey()
         } catch {
             throw error
         }


### PR DESCRIPTION
When MemfaultManager requests DeviceInfo and Project Key via the new Memfault Group, we now properly log errors, so they're visible in "red" in the Xcode console, as well as sent upwards via the logDelegate, obviously. So, all API users win as well.