### PR TITLE
feat(memfault): include app version in user agent

### DIFF
--- a/iOSOtaLibrary/Source/OTA/GetLatestReleaseInfoRequest.swift
+++ b/iOSOtaLibrary/Source/OTA/GetLatestReleaseInfoRequest.swift
@@ -28,9 +28,14 @@ extension HTTPRequest {
             return nil
         }
         request.setMethod(HTTPMethod.GET)
+
+        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
+        let userAgent = "nRF Device Manager/\(appVersion)"
+
         request.setHeaders([
             "Accept": "application/json",
-            "Memfault-Project-Key": key.authKey
+            "Memfault-Project-Key": key.authKey,
+            "User-Agent": userAgent
         ])
         return request
     }

--- a/iOSOtaLibrary/Source/Observability/PostChunkRequest.swift
+++ b/iOSOtaLibrary/Source/Observability/PostChunkRequest.swift
@@ -12,13 +12,18 @@ import iOS_Common_Libraries
 // MARK: - PostChunkRequest
 
 extension HTTPRequest {
-    
+
     static func post(_ chunk: ObservabilityChunk, with chunkAuth: ObservabilityAuth) -> HTTPRequest {
         var httpRequest = HTTPRequest(url: chunkAuth.url)
         httpRequest.setMethod(HTTPMethod.POST)
+
+        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
+        let userAgent = "nRF Device Manager/\(appVersion)"
+
         httpRequest.setHeaders([
             "Content-Type": "application/octet-stream",
-            chunkAuth.authKey: chunkAuth.authValue
+            chunkAuth.authKey: chunkAuth.authValue,
+            "User-Agent": userAgent
         ])
         httpRequest.setBody(chunk.data)
         return httpRequest
@@ -28,7 +33,7 @@ extension HTTPRequest {
 // MARK: - ObservabilityAuth
 
 public struct ObservabilityAuth {
-    
+
     let url: URL
     let authKey: String
     let authValue: String


### PR DESCRIPTION
Can be helpful for debugging, insert the app version into the user agent sent in HTTP requests to Memfault.