### PR TITLE
fix(memfault): url-encode query params to /latest endpoint

### DIFF
--- a/iOSOtaLibrary/Source/OTA/GetLatestReleaseInfoRequest.swift
+++ b/iOSOtaLibrary/Source/OTA/GetLatestReleaseInfoRequest.swift
@@ -12,16 +12,16 @@ import iOS_Common_Libraries
 // MARK: - getLatestReleaseInfo
 
 extension HTTPRequest {
-    
+
     /**
      Source: https://api-docs.memfault.com/#89d8dfa4-10d7-41d3-9c20-7cc356030c4b
      */
     static func getLatestReleaseInfo(token: DeviceInfoToken, key: ProjectKey) -> HTTPRequest? {
         let parameters: [String: String] = [
-            "hardware_version": token.hardwareVersion,
-            "software_type": token.softwareType,
-            "current_version": token.currentVersion,
-            "device_serial": token.deviceSerialNumber
+            "hardware_version": token.hardwareVersion.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.hardwareVersion,
+            "software_type": token.softwareType.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.softwareType,
+            "current_version": token.currentVersion.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.currentVersion,
+            "device_serial": token.deviceSerialNumber.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.deviceSerialNumber
         ]
         // https://api.memfault.com/api/v0/releases/latest
         guard var request = HTTPRequest(scheme: .https, host: "api.memfault.com", path: "/api/v0/releases/latest", parameters: parameters) else {
@@ -39,9 +39,9 @@ extension HTTPRequest {
 // MARK: - LatestReleaseInfo
 
 public struct LatestReleaseInfo: Codable {
-    
+
     // MARK: Properties
-    
+
     public let id: Int
     public let createdDate: Date
     public let version: String
@@ -56,9 +56,9 @@ public struct LatestReleaseInfo: Codable {
 // MARK: - ReleaseArtifact
 
 public struct ReleaseArtifact: Codable {
-    
+
     // MARK: Properties
-    
+
     public let id: Int
     public let createdDate: Date
     public let type: String
@@ -69,9 +69,9 @@ public struct ReleaseArtifact: Codable {
     public let md5: String
     public let sha1: String
     public let sha256: String
-    
+
     // MARK: sizeString()
-    
+
     public func sizeString() -> String {
         guard #available(iOS 16.0, macCatalyst 16.0, macOS 13.0, *) else {
             return "\(fileSize) bytes"
@@ -79,9 +79,9 @@ public struct ReleaseArtifact: Codable {
         let fileSizeMeasurement = Measurement<UnitInformationStorage>(value: Double(fileSize), unit: .bytes)
         return fileSizeMeasurement.formatted(.byteCount(style: .file))
     }
-    
+
     // MARK: releaseURL()
-    
+
     public func releaseURL() -> URL? {
         return URL(string: url)
     }


### PR DESCRIPTION
Device properties other than serial number can contain non-URL-safe character sequences (device serial is limited to `^[-a-zA-Z0-9_]+$`, [reference
here](https://docs.memfault.com/docs/platform/memfault-terminology#device-id)).

To make sure they are passed correctly to the `/latest` OTA endpoint, URL-encode the params (this is also done in the memfault-cloud-ios and memfault-cloud-android helper libraries).