### PR TITLE
fix(memfault): url-encode query params to /latest endpoint

### DIFF
--- a/iOSOtaLibrary/Source/OTA/GetLatestReleaseInfoRequest.swift
+++ b/iOSOtaLibrary/Source/OTA/GetLatestReleaseInfoRequest.swift
@@ -18,10 +18,10 @@ extension HTTPRequest {
      */
     static func getLatestReleaseInfo(token: DeviceInfoToken, key: ProjectKey) -> HTTPRequest? {
         let parameters: [String: String] = [
-            "hardware_version": token.hardwareVersion,
-            "software_type": token.softwareType,
-            "current_version": token.currentVersion,
-            "device_serial": token.deviceSerialNumber
+            "hardware_version": token.hardwareVersion.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.hardwareVersion,
+            "software_type": token.softwareType.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.softwareType,
+            "current_version": token.currentVersion.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.currentVersion,
+            "device_serial": token.deviceSerialNumber.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token.deviceSerialNumber
         ]
         // https://api.memfault.com/api/v0/releases/latest
         guard var request = HTTPRequest(scheme: .https, host: "api.memfault.com", path: "/api/v0/releases/latest", parameters: parameters) else {


### PR DESCRIPTION
Device properties other than serial number can contain non-URL-safe character sequences (device serial is limited to `^[-a-zA-Z0-9_]+$`, [reference here](https://docs.memfault.com/docs/platformmemfault-terminology#device-id)).

To make sure they are passed correctly to the `/latest` OTA endpoint, URL-encode the params (this is also done in the memfault-cloud-ios and memfault-cloud-android helper libraries).