### PR TITLE
Breaking API Change: DeviceInfoToken(s) cannot be initialised with empty values

### DIFF
--- a/Example/Example/Util/DeviceInfoManager.swift
+++ b/Example/Example/Util/DeviceInfoManager.swift
@@ -129,7 +129,7 @@ extension DeviceInfoManager {
                 throw DeviceInfoManagerError.incompleteDeviceInfo
             }
             
-            return DeviceInfoToken(deviceSerialNumber: serial, hardwareVersion: hardwareVersion, currentVersion: firmwareVersion, softwareType: softwareType)
+            return try DeviceInfoToken(deviceSerialNumber: serial, hardwareVersion: hardwareVersion, currentVersion: firmwareVersion, softwareType: softwareType)
         }
     }
     

--- a/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
+++ b/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
@@ -39,7 +39,7 @@ public class MemfaultManager: McuManager {
             if let error = response?.getError() {
                 throw error
             }
-            guard let token = response?.deviceToken() else {
+            guard let token = try response?.deviceToken() else {
                 throw OTAManagerError.unableToParseResponse
             }
             return token
@@ -109,10 +109,10 @@ public final class MemfaultDeviceInfoResponse: McuMgrResponse {
         }
     }
     
-    public func deviceToken() -> DeviceInfoToken? {
+    public func deviceToken() throws(DeviceInfoTokenError) -> DeviceInfoToken? {
         guard let serial, let hardware, let software, let version else { return nil }
-        return DeviceInfoToken(deviceSerialNumber: serial, hardwareVersion: hardware,
-                               currentVersion: version, softwareType: software)
+        return try DeviceInfoToken(deviceSerialNumber: serial, hardwareVersion: hardware,
+                                   currentVersion: version, softwareType: software)
     }
 }
 

--- a/iOSOtaLibrary/Source/OTA/Tokens/DeviceInfoToken.swift
+++ b/iOSOtaLibrary/Source/OTA/Tokens/DeviceInfoToken.swift
@@ -21,10 +21,31 @@ public struct DeviceInfoToken {
     
     // MARK: init
     
-    public init(deviceSerialNumber: String, hardwareVersion: String, currentVersion: String, softwareType: String) {
+    public init(deviceSerialNumber: String, hardwareVersion: String, currentVersion: String, softwareType: String) throws(DeviceInfoTokenError) {
+        guard !deviceSerialNumber.isEmpty, !hardwareVersion.isEmpty, !currentVersion.isEmpty, !softwareType.isEmpty else {
+            throw .emptyFieldFound
+        }
+        
         self.deviceSerialNumber = deviceSerialNumber
         self.hardwareVersion = hardwareVersion
         self.currentVersion = currentVersion
         self.softwareType = softwareType
     }
+}
+
+// MARK: - DeviceInfoTokenError
+
+public enum DeviceInfoTokenError: LocalizedError {
+    case emptyFieldFound
+    
+    public var errorDescription: String? {
+        switch self {
+        case .emptyFieldFound:
+            return "DeviceInfoToken fields cannot be empty strings."
+        }
+    }
+    
+    public var failureReason: String? { errorDescription }
+    
+    public var recoverySuggestion: String? { errorDescription }
 }


### PR DESCRIPTION
At this moment, this seems like the best way to implement this going forward. It can allow some other form of cleanup which I can follow-up on. But as is usually the case, it is unknown at this time if further changes will come back to haunt us regarding this decision.