### PR TITLE
Update user agent to include OS information

### DIFF
--- a/iOSOtaLibrary/Source/Observability/PostChunkRequest.swift
+++ b/iOSOtaLibrary/Source/Observability/PostChunkRequest.swift
@@ -27,11 +27,21 @@ extension HTTPRequest {
 }
 
 extension HTTPRequest {
-    
+
     static func otaLibraryUserAgent() -> String {
-        let appVersion = Constant.appVersion(forBundleWithClass: OTAManager.self)
-            .replacingOccurrences(of: " ", with: "")
-        return "iOSOtaLibraryClient/\(appVersion)"
+        let bundle = Bundle(for: OTAManager.self)
+        let appName = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Device Manager"
+        let appVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0.0"
+        let buildNumber = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "1"
+
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let darwinVersion = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+
+        // Get CFNetwork version from the system
+        let cfNetworkVersion = Bundle(identifier: "com.apple.CFNetwork")?
+            .object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String ?? "Unknown"
+
+        return "\(appName) \(appVersion)/\(buildNumber) CFNetwork/\(cfNetworkVersion) Darwin/\(darwinVersion)"
     }
 }
 


### PR DESCRIPTION
This is used in Memfault to generate some automatic metrics showing user agent OS type (iOS) and version, so let's try to mimic the default user agent scheme, example:

```
Device%20Manager/9 CFNetwork/3826.600.41 Darwin/24.6.0
```

But keep the version number information.