### PR TITLE
Fix: Add support for McuMgrReturnCode busy (RC: 10)

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
@@ -464,7 +464,7 @@ public class ImageManager: McuManager {
         }
         
         if let error = response.getError() {
-            self.cancelUpload(error: error)
+            self.onUploadResponseError(error, for: response)
             return
         }
         
@@ -532,6 +532,26 @@ public class ImageManager: McuManager {
             self.cancelUpload(error: ImageUploadError.invalidPayload)
         }
     }
+    
+    // MARK: onUploadResponseError(_:for:)
+    
+    private func onUploadResponseError(_ error: any LocalizedError, for response: McuMgrUploadResponse) {
+        if case let McuMgrError.returnCode(.busy) = error {
+            log(msg: "Received 'busy' Error from Device. Will try again after a short day.", atLevel: .debug)
+            if let offset = response.off {
+                Timer.scheduledTimer(withTimeInterval: McuManager.BUSY_WAIT_DELAY_MS, repeats: false) { [weak self] timer in
+                    self?.sendNext(from: offset)
+                }
+                return // prevent Upload Cancellation.
+            } else {
+                log(msg: "Error retrieving current Upload offset. Can't retry after Busy response.", atLevel: .error)
+            }
+        }
+        
+        cancelUpload(error: error)
+    }
+    
+    // MARK: sendNext(from:)
     
     private func sendNext(from offset: UInt64) {
         let imageData: Data! = uploadImages?[uploadIndex].data

--- a/iOSMcuManagerLibrary/Source/McuManager.swift
+++ b/iOSMcuManagerLibrary/Source/McuManager.swift
@@ -48,6 +48,16 @@ open class McuManager: NSObject {
     /// This is the default time to wait for a command to be sent, executed
     /// and received (responded to) by the firmware on the other end.
     public static let FAST_TIMEOUT = 10
+    /**
+     When encountering a ``McuMgrReturnCode/busy`` value during an Upload,
+     instead of responding with an Error and cancelling the Upload, we can
+     try to wait a very brief amount of time and retry sending the same Data.
+     
+     This return ``McuMgrError`` code, ``McuMgrReturnCode/busy``, can be caused
+     by the target firmware having external flash memory it needs to write to
+     during DFU. This external memory is, of course, slower.
+     */
+    public static let BUSY_WAIT_DELAY_MS: TimeInterval = 0.1
     
     //**************************************************************************
     // MARK: Properties


### PR DESCRIPTION
Instead of cancelling Image Upload with an Error, we instead attempt to retry sending the affected offset if RC 10 is received. This can be triggered when DFU is being performed on a device that needs to write to external flash memory.