### PR TITLE
Bump macOS Package requirement to 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "iOSMcuManagerLibrary",
-    platforms: [.iOS(.v13), .macOS(.v10_14)],
+    platforms: [.iOS(.v13), .macOS(.v10_15)],
     products: [
         .library(
             name: "iOSMcuManagerLibrary",


### PR DESCRIPTION
We don't want to raise it on the iOS side if it can be avoided. GitHub Issue: https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/542