### PR TITLE
(Crash) Fix for Memfault Continuation resuming twice

### DIFF
--- a/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
+++ b/iOSOtaLibrary/Source/OTA/MemfaultManager.swift
@@ -75,6 +75,7 @@ public class MemfaultManager: McuManager {
             let callback: McuMgrCallback<R> = { response, error in
                 if let error {
                     continuation.resume(throwing: error)
+                    return
                 }
                 continuation.resume(returning: response)
             }


### PR DESCRIPTION
This happens in case of an error being encountered. We forget that guards are not ifs.