### PR TITLE
New DeviceStatus Manager + DefaultManager Async

### DIFF
--- a/Example/Example/State/DeviceStatusManager.swift
+++ b/Example/Example/State/DeviceStatusManager.swift
@@ -1,0 +1,121 @@
+//
+//  DeviceStatusState.swift
+//  nRF Connect Device Manager
+//
+//  Created by Dinesh Harjani on 26/3/26.
+//  Copyright © 2026 Nordic Semiconductor ASA. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import iOSMcuManagerLibrary
+import iOSOtaLibrary
+
+// MARK: - DeviceStatusManager
+
+final class DeviceStatusManager {
+    
+    // MARK: Private Properties
+    
+    private weak var transport: McuMgrTransport?
+    private weak var logDelegate: (any McuMgrLogDelegate)?
+    private let defaultManager: DefaultManager
+    
+    // MARK: Properties
+    
+    private(set) var mcuMgrParams: (bufferCount: Int, bufferSize: Int)?
+    private(set) var appInfoOutput: String?
+    private(set) var bootloader: BootloaderInfoResponse.Bootloader?
+    private(set) var bootloaderMode: BootloaderInfoResponse.Mode?
+    private(set) var bootloaderSlot: UInt64?
+    private(set) var otaStatus: OTAStatus?
+    
+    // MARK: init
+    
+    init(_ transport: McuMgrTransport, logDelegate: (any McuMgrLogDelegate)?) {
+        self.transport = transport
+        self.logDelegate = logDelegate
+        self.defaultManager = DefaultManager(transport: transport)
+        defaultManager.logDelegate = logDelegate
+    }
+}
+
+// MARK: API
+
+extension DeviceStatusManager {
+    
+    // MARK: requestStatus
+    
+    func requestStatus() async {
+        async let mcuMgrParams = defaultManager.params()
+        async let appInfo = defaultManager.applicationInfo(format: [.kernelName, .kernelVersion])
+        async let bootloaderInfo = defaultManager.bootloaderInfo()
+        
+        self.mcuMgrParams = try? await mcuMgrParams
+        self.appInfoOutput = try? await appInfo
+        self.bootloader = try? await bootloaderInfo.bootloader
+        self.bootloaderMode = try? await bootloaderInfo.mode
+        self.bootloaderSlot = try? await bootloaderInfo.slot
+    }
+    
+    // MARK: requestOTAStatus
+    
+    func requestOTAStatus(for peripheralUUID: UUID) async {
+        let deviceInfoManager = DeviceInfoManager(peripheralUUID)
+        do {
+            let tokens = try await requestTokensViaMemfaultManager()
+            otaStatus = .supported(tokens.0, tokens.1)
+        } catch {
+            // Disregard error. Try again through Device Information.
+            var deviceInfo: DeviceInfoToken!
+            do {
+                deviceInfo = try await deviceInfoManager.getDeviceInfoToken()
+                let projectKey = try await deviceInfoManager.getProjectKey()
+                otaStatus = .supported(deviceInfo, projectKey)
+            } catch let managerError as DeviceInfoManagerError {
+                if deviceInfo != nil {
+                    otaStatus = .missingProjectKey(deviceInfo, managerError)
+                } else {
+                    otaStatus = .unsupported(managerError)
+                }
+            } catch let error {
+                otaStatus = .unsupported(error)
+            }
+        }
+    }
+}
+
+// MARK: - Private
+
+fileprivate extension DeviceStatusManager {
+    
+    // MARK: requestTokensViaMemfaultManager
+    
+    func requestTokensViaMemfaultManager() async throws -> (DeviceInfoToken, ProjectKey) {
+        guard let transport else {
+            throw ObservabilityError.mdsServiceNotFound
+        }
+        let otaManager = OTAManager()
+        otaManager.logDelegate = logDelegate
+        let deviceInfo = try await otaManager.getDeviceInfoToken(via: transport)
+        let projectKey = try await otaManager.getProjectKey(via: transport)
+        return (deviceInfo, projectKey)
+    }
+}
+
+// MARK: - Delegate
+
+extension DeviceStatusManager {
+    
+    protocol Delegate: AnyObject {
+        
+        func connectionStateDidChange(_ state: PeripheralState)
+        func bootloaderNameReceived(_ name: String)
+        func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode)
+        func bootloaderSlotReceived(_ slot: UInt64)
+        func appInfoReceived(_ output: String)
+        func mcuMgrParamsReceived(buffers: Int, size: Int)
+        func otaStatusChanged(_ status: OTAStatus)
+        func observabilityStatusChanged(_ status: ObservabilityStatus, pendingCount: Int, pendingBytes: Int, uploadedCount: Int, uploadedBytes: Int)
+    }
+}

--- a/Example/Example/Util/DefaultManager+Task.swift
+++ b/Example/Example/Util/DefaultManager+Task.swift
@@ -1,0 +1,84 @@
+//
+//  DefaultManager+Task.swift
+//  nRF Connect Device Manager
+//
+//  Created by Dinesh Harjani on 26/3/26.
+//  Copyright © 2026 Nordic Semiconductor ASA. All rights reserved.
+//
+
+import Foundation
+import iOSMcuManagerLibrary
+
+// MARK: - DefaultManager+Task
+
+extension DefaultManager {
+    
+    // MARK: async params()
+    
+    func params() async throws -> (bufferCount: Int, bufferSize: Int) {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(bufferCount: Int, bufferSize: Int), Error>) in
+            params { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let count = response?.bufferCount,
+                   let size = response?.bufferSize {
+                    continuation.resume(returning: (Int(count), Int(size)))
+                } else {
+                    continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
+                }
+            }
+        }
+    }
+    
+    // MARK: async applicationInfo(format:)
+    
+    func applicationInfo(format: Set<ApplicationInfoFormat>) async throws -> String {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            applicationInfo(format: format) { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let response = response?.response {
+                    continuation.resume(returning: response)
+                } else {
+                    continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
+                }
+            }
+        }
+    }
+    
+    // MARK: bootloaderInfo()
+    
+    func bootloaderInfo() async throws -> (bootloader: BootloaderInfoResponse.Bootloader?, mode: BootloaderInfoResponse.Mode?, slot: UInt64?) {
+        let bootloader = try await bootloaderQuery(.name).bootloader
+        guard bootloader == .mcuboot else { return (bootloader: bootloader, mode: nil, slot: nil) }
+        
+        let mode = try await bootloaderQuery(.mode).mode
+        let slot = try await bootloaderQuery(.slot).activeSlot
+        return (bootloader: bootloader, mode: mode, slot: slot)
+    }
+    
+    // MARK: bootloaderQuery(:)
+    
+    func bootloaderQuery(_ query: BootloaderInfoQuery) async throws -> BootloaderInfoResponse {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BootloaderInfoResponse, Error>) in
+            bootloaderInfo(query: query) { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let response {
+                    continuation.resume(returning: response)
+                } else {
+                    continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
+                }
+            }
+        }
+    }
+}

--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -9,20 +9,6 @@ import CoreBluetooth
 import iOSMcuManagerLibrary
 import iOSOtaLibrary
 
-// MARK: - DeviceStatusDelegate
-
-protocol DeviceStatusDelegate: AnyObject {
-    
-    func connectionStateDidChange(_ state: PeripheralState)
-    func bootloaderNameReceived(_ name: String)
-    func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode)
-    func bootloaderSlotReceived(_ slot: UInt64)
-    func appInfoReceived(_ output: String)
-    func mcuMgrParamsReceived(buffers: Int, size: Int)
-    func otaStatusChanged(_ status: OTAStatus)
-    func observabilityStatusChanged(_ status: ObservabilityStatus, pendingCount: Int, pendingBytes: Int, uploadedCount: Int, uploadedBytes: Int)
-}
-
 // MARK: - DeviceStatusRow
 
 enum DeviceStatusRow: Int, CustomStringConvertible {
@@ -63,7 +49,7 @@ final class BaseViewController: UITabBarController {
     
     // MARK: Properties
     
-    weak var deviceStatusDelegate: DeviceStatusDelegate? {
+    weak var deviceStatusDelegate: DeviceStatusManager.Delegate? {
         didSet {
             if let peripheralState {
                 deviceStatusDelegate?.connectionStateDidChange(peripheralState)
@@ -81,7 +67,7 @@ final class BaseViewController: UITabBarController {
                 deviceStatusDelegate?.appInfoReceived(appInfoOutput)
             }
             if let mcuMgrParams {
-                deviceStatusDelegate?.mcuMgrParamsReceived(buffers: mcuMgrParams.buffers, size: mcuMgrParams.size)
+                deviceStatusDelegate?.mcuMgrParamsReceived(buffers: mcuMgrParams.bufferCount, size: mcuMgrParams.bufferSize)
             }
             if let otaStatus {
                 deviceStatusDelegate?.otaStatusChanged(otaStatus)
@@ -108,8 +94,7 @@ final class BaseViewController: UITabBarController {
     
     // MARK: Private Properties
     
-    private var otaManager: OTAManager?
-    private var deviceInfoManager: DeviceInfoManager?
+    private var deviceStatusManager: DeviceStatusManager?
     
     private var observabilityTask: Task<Void, Never>?
     private var observabilityIdentifier: UUID?
@@ -158,10 +143,10 @@ final class BaseViewController: UITabBarController {
         }
     }
     
-    private var mcuMgrParams: (buffers: Int, size: Int)? {
+    private var mcuMgrParams: (bufferCount: Int, bufferSize: Int)? {
         didSet {
             guard let mcuMgrParams else { return }
-            deviceStatusDelegate?.mcuMgrParamsReceived(buffers: mcuMgrParams.buffers, size: mcuMgrParams.size)
+            deviceStatusDelegate?.mcuMgrParamsReceived(buffers: mcuMgrParams.bufferCount, size: mcuMgrParams.bufferSize)
         }
     }
     
@@ -204,6 +189,8 @@ final class BaseViewController: UITabBarController {
         disconnect()
     }
     
+    // MARK: disconnect()
+    
     func disconnect() {
         if let observabilityIdentifier {
             observabilityManager?.disconnect(from: observabilityIdentifier)
@@ -225,41 +212,28 @@ extension BaseViewController {
             return
         }
         
-        let defaultManager = DefaultManager(transport: transport)
-        defaultManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
-        defaultManager.params { [weak self] response, error in
-            if let count = response?.bufferCount,
-               let size = response?.bufferSize {
-                self?.mcuMgrParams = (Int(count), Int(size))
-            }
+        if deviceStatusManager == nil {
+            deviceStatusManager = DeviceStatusManager(
+                transport, logDelegate: UIApplication.shared.delegate as? McuMgrLogDelegate
+            )
+        }
+        guard let deviceStatusManager else { return }
+        
+        Task { @MainActor in
+            await deviceStatusManager.requestStatus()
+            mcuMgrParams = deviceStatusManager.mcuMgrParams
+            appInfoOutput = deviceStatusManager.appInfoOutput
+            bootloader = deviceStatusManager.bootloader
+            bootloaderMode = deviceStatusManager.bootloaderMode
+            bootloaderSlot = deviceStatusManager.bootloaderSlot
             
-            self?.requestApplicationInfo(defaultManager)
-        }
-    }
-    
-    private func requestApplicationInfo(_ defaultManager: DefaultManager) {
-        defaultManager.applicationInfo(format: [.kernelName, .kernelVersion]) { [weak self] response, error in
-            self?.appInfoOutput = response?.response
-            self?.requestBootloaderInfo(defaultManager)
-        }
-    }
-    
-    private func requestBootloaderInfo(_ defaultManager: DefaultManager) {
-        defaultManager.bootloaderInfo(query: .name) { [weak self] response, error in
-            self?.bootloader = response?.bootloader
-            guard response?.bootloader == .mcuboot else {
-                self?.requestOTAReleaseInfo()
+            guard let peripheral = peripheral?.basePeripheral else {
+                onDeviceStatusFinished()
                 return
             }
-            
-            defaultManager.bootloaderInfo(query: .mode) { [weak self] response, error in
-                self?.bootloaderMode = response?.mode
-                
-                defaultManager.bootloaderInfo(query: .slot) { [weak self] response, error in
-                    self?.bootloaderSlot = response?.activeSlot
-                    self?.requestOTAReleaseInfo()
-                }
-            }
+            await deviceStatusManager.requestOTAStatus(for: peripheral.identifier)
+            otaStatus = deviceStatusManager.otaStatus
+            onDeviceStatusFinished()
         }
     }
     
@@ -270,64 +244,6 @@ extension BaseViewController {
         statusInfoCallback()
         deviceInfoRequested = true
         self.statusInfoCallback = nil
-    }
-}
- 
-// MARK: - OTA
-
-private extension BaseViewController {
-    
-    func requestOTAReleaseInfo() {
-        guard let deviceInfoManager else { return }
-        Task { @MainActor in
-            do {
-                let tokens = try await requestTokensViaMemfaultManager()
-                otaStatus = .supported(tokens.0, tokens.1)
-                onDeviceStatusFinished()
-            } catch {
-                // Disregard error. Try again through Device Information.
-                var deviceInfo: DeviceInfoToken!
-                do {
-                    deviceInfo = try await deviceInfoManager.getDeviceInfoToken()
-                    let projectKey = try await deviceInfoManager.getProjectKey()
-                    otaStatus = .supported(deviceInfo, projectKey)
-                    onDeviceStatusFinished()
-                } catch let managerError as DeviceInfoManagerError {
-                    if deviceInfo != nil {
-                        otaStatus = .missingProjectKey(deviceInfo, managerError)
-                    } else {
-                        otaStatus = .unsupported(managerError)
-                    }
-                    onDeviceStatusFinished()
-                } catch let error {
-                    otaStatus = .unsupported(error)
-                    onDeviceStatusFinished()
-                }
-            }
-        }
-    }
-    
-    // MARK: requestTokensViaMemfaultManager
-    
-    func requestTokensViaMemfaultManager() async throws -> (DeviceInfoToken, ProjectKey) {
-        guard let otaManager else {
-            throw ObservabilityError.mdsServiceNotFound
-        }
-        otaManager.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
-        let deviceInfo = try await otaManager.getDeviceInfoToken(via: transport)
-        let projectKey = try await otaManager.getProjectKey(via: transport)
-        return (deviceInfo, projectKey)
-    }
-    
-    // MARK: requestTokensViaDeviceInformation
-    
-    func requestTokensViaDeviceInformation() async throws -> (DeviceInfoToken, ProjectKey) {
-        guard let deviceInfoManager else {
-            throw DeviceInfoManagerError.peripheralNotFound
-        }
-        let deviceInfo = try await deviceInfoManager.getDeviceInfoToken()
-        let projectKey = try await deviceInfoManager.getProjectKey()
-        return (deviceInfo, projectKey)
     }
 }
  
@@ -494,7 +410,6 @@ extension BaseViewController {
     
     func onDFUStart() {
         stopObservabilityManagerAndTask()
-        otaManager = nil
     }
 }
 
@@ -506,16 +421,12 @@ extension BaseViewController: PeripheralDelegate {
         peripheralState = state
         switch state {
         case .connected:
-            otaManager = OTAManager()
-            deviceInfoManager = DeviceInfoManager(peripheral.identifier)
             observabilityManager = ObservabilityManager()
             observabilityIdentifier = peripheral.identifier
             launchObservabilityTask()
         case .disconnecting, .disconnected:
             // Set to false, because a DFU update might change things if that's what happened.
             deviceInfoRequested = false
-            otaManager = nil
-            deviceInfoManager = nil
             stopObservabilityManagerAndTask()
         default:
             // Nothing to do here.

--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -144,7 +144,7 @@ class DeviceController: UITableViewController, UITextFieldDelegate {
 
 // MARK: - DeviceStatusdelegate
 
-extension DeviceController: DeviceStatusDelegate {
+extension DeviceController: DeviceStatusManager.Delegate {
     
     func connectionStateDidChange(_ state: PeripheralState) {
         connectionStatus.text = state.description

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -180,7 +180,7 @@ private extension DiagnosticsController {
 
 // MARK: - DeviceStatusDelegate
 
-extension DiagnosticsController: DeviceStatusDelegate {
+extension DiagnosticsController: DeviceStatusManager.Delegate {
     
     func connectionStateDidChange(_ state: PeripheralState) {
         connectionStatus.text = state.description

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -104,7 +104,7 @@ final class FilesController: UITableViewController {
 
 // MARK: - DeviceStatusDelegate
 
-extension FilesController: DeviceStatusDelegate {
+extension FilesController: DeviceStatusManager.Delegate {
     
     func connectionStateDidChange(_ state: PeripheralState) {
         connectionStatus.text = state.description

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -120,7 +120,7 @@ final class ImageController: UITableViewController {
 
 // MARK: - DeviceStatusDelegate
 
-extension ImageController: DeviceStatusDelegate {
+extension ImageController: DeviceStatusManager.Delegate {
     
     func connectionStateDidChange(_ state: PeripheralState) {
         connectionStatus.text = state.description

--- a/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		AA7145062F6D9FF800AF4BE7 /* AppMainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7145052F6D9FF800AF4BE7 /* AppMainSceneDelegate.swift */; };
 		AA7799F82E785BA800CAA1C3 /* iOSMcuManagerLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = AA7799F72E785BA800CAA1C3 /* iOSMcuManagerLibrary */; };
 		AA8404C42E7832ED00BD6B4A /* CryptoKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA8404C32E7832ED00BD6B4A /* CryptoKit.framework */; };
+		AA8C1BA62F7543FC00234E5F /* DeviceStatusManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8C1BA52F7543FC00234E5F /* DeviceStatusManager.swift */; };
+		AA8C1BA82F75526B00234E5F /* DefaultManager+Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8C1BA72F75526B00234E5F /* DefaultManager+Task.swift */; };
 		AAC0F0362E670D38006E0ADD /* iOSOtaLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = AAC0F0352E670D38006E0ADD /* iOSOtaLibrary */; };
 		BD5A285820CB44AF0061F0EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A285720CB44AF0061F0EE /* AppDelegate.swift */; };
 		BD5A285A20CB44AF0061F0EE /* ScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5A285920CB44AF0061F0EE /* ScannerViewController.swift */; };
@@ -69,6 +71,8 @@
 		AA5710122E829E0D001544D0 /* OTAStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTAStatus.swift; sourceTree = "<group>"; };
 		AA7145052F6D9FF800AF4BE7 /* AppMainSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMainSceneDelegate.swift; sourceTree = "<group>"; };
 		AA8404C32E7832ED00BD6B4A /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
+		AA8C1BA52F7543FC00234E5F /* DeviceStatusManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStatusManager.swift; sourceTree = "<group>"; };
+		AA8C1BA72F75526B00234E5F /* DefaultManager+Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultManager+Task.swift"; sourceTree = "<group>"; };
 		BD54DE5320CEE16F0023F980 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
 		BD5A285420CB44AF0061F0EE /* nRF Connect Device Manager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "nRF Connect Device Manager.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD5A285720CB44AF0061F0EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				AA12B39F2E79885600378F1E /* DeviceInfoManager.swift */,
+				AA8C1BA72F75526B00234E5F /* DefaultManager+Task.swift */,
 				524DCFD8210B4241000E110D /* UIColor.swift */,
 				F07D73AB2AE9AE3A00ED6B9A /* StringConvertibles.swift */,
 				AA5710102E829DD4001544D0 /* ObservabilityStatus.swift */,
@@ -181,6 +186,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		AA8C1BA42F7543E000234E5F /* State */ = {
+			isa = PBXGroup;
+			children = (
+				AA8C1BA52F7543FC00234E5F /* DeviceStatusManager.swift */,
+			);
+			path = State;
+			sourceTree = "<group>";
+		};
 		BD5A284B20CB44AF0061F0EE = {
 			isa = PBXGroup;
 			children = (
@@ -204,6 +217,7 @@
 				BD54DE5320CEE16F0023F980 /* Example.entitlements */,
 				5246368C2108DEFC008B3D5B /* Model */,
 				524636882108DCF1008B3D5B /* View Controllers */,
+				AA8C1BA42F7543E000234E5F /* State */,
 				524DCFD7210B421E000E110D /* Util */,
 				BD5A285720CB44AF0061F0EE /* AppDelegate.swift */,
 				AA7145052F6D9FF800AF4BE7 /* AppMainSceneDelegate.swift */,
@@ -348,6 +362,8 @@
 				524DCFD0210B0EB6000E110D /* BaseViewController.swift in Sources */,
 				521576312126CC8F00C21B0C /* FileUploadViewController.swift in Sources */,
 				5274C2622796CEC40043D7CA /* SettingsViewController.swift in Sources */,
+				AA8C1BA82F75526B00234E5F /* DefaultManager+Task.swift in Sources */,
+				AA8C1BA62F7543FC00234E5F /* DeviceStatusManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Task.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Task.swift
@@ -1,0 +1,84 @@
+//
+//  DefaultManager+Task.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 26/3/26.
+//  Copyright © 2026 Nordic Semiconductor ASA. All rights reserved.
+//
+
+import Foundation
+import iOSMcuManagerLibrary
+
+// MARK: - DefaultManager+Task
+
+extension DefaultManager {
+    
+    // MARK: async params()
+    
+    func params() async throws -> (bufferCount: Int, bufferSize: Int) {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(bufferCount: Int, bufferSize: Int), Error>) in
+            params { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let count = response?.bufferCount,
+                   let size = response?.bufferSize {
+                    continuation.resume(returning: (Int(count), Int(size)))
+                } else {
+                    continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
+                }
+            }
+        }
+    }
+    
+    // MARK: async applicationInfo(format:)
+    
+    func applicationInfo(format: Set<ApplicationInfoFormat>) async throws -> String {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            applicationInfo(format: format) { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let response = response?.response {
+                    continuation.resume(returning: response)
+                } else {
+                    continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
+                }
+            }
+        }
+    }
+    
+    // MARK: bootloaderInfo()
+    
+    func bootloaderInfo() async throws -> (bootloader: BootloaderInfoResponse.Bootloader?, mode: BootloaderInfoResponse.Mode?, slot: UInt64?) {
+        let bootloader = try await bootloaderQuery(.name).bootloader
+        guard bootloader == .mcuboot else { return (bootloader: bootloader, mode: nil, slot: nil) }
+        
+        let mode = try await bootloaderQuery(.mode).mode
+        let slot = try await bootloaderQuery(.slot).activeSlot
+        return (bootloader: bootloader, mode: mode, slot: slot)
+    }
+    
+    // MARK: bootloaderQuery(:)
+    
+    func bootloaderQuery(_ query: BootloaderInfoQuery) async throws -> BootloaderInfoResponse {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BootloaderInfoResponse, Error>) in
+            bootloaderInfo(query: query) { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let response {
+                    continuation.resume(returning: response)
+                } else {
+                    continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The goal here is to move the logic that handles "onDeviceStatusReady" off the BaseVC. Either to make it more reusable, or to provide us with a much better jumping off point for SwiftUI integration. Async wrapper variants were added to DefaultManager. We want to use newer APIs and we expect our customers would want to do the same, too. They must've already done so.