### PR TITLE
DeviceStatusDelegate Cleanup

### DIFF
--- a/Example/Example/State/DeviceStatusManager.swift
+++ b/Example/Example/State/DeviceStatusManager.swift
@@ -21,16 +21,6 @@ final class DeviceStatusManager {
     private weak var logDelegate: (any McuMgrLogDelegate)?
     private let defaultManager: DefaultManager
     
-    // MARK: Properties
-    
-    private(set) var bufferCount: UInt64?
-    private(set) var bufferSize: UInt64?
-    private(set) var appInfoOutput: String?
-    private(set) var bootloader: BootloaderInfoResponse.Bootloader?
-    private(set) var bootloaderMode: BootloaderInfoResponse.Mode?
-    private(set) var bootloaderSlot: UInt64?
-    private(set) var otaStatus: OTAStatus?
-    
     // MARK: init
     
     init(_ transport: McuMgrTransport, logDelegate: (any McuMgrLogDelegate)?) {
@@ -45,45 +35,47 @@ final class DeviceStatusManager {
 
 extension DeviceStatusManager {
     
-    // MARK: requestStatus
+    // MARK: requestStatusInfo
     
-    func requestStatus() async {
+    func requestStatusInfo() async -> DeviceStatusInfo {
         async let mcuMgrParametersResponse = defaultManager.params()
         async let appInfoResponse = defaultManager.applicationInfo(format: [.kernelName, .kernelVersion])
         async let bootloaderInfo = defaultManager.bootloaderInfo()
         
+        var info = DeviceStatusInfo()
         if let mcuMgrParams = try? await mcuMgrParametersResponse {
-            self.bufferSize = mcuMgrParams.bufferSize
-            self.bufferCount = mcuMgrParams.bufferCount
+            info.bufferSize = mcuMgrParams.bufferSize
+            info.bufferCount = mcuMgrParams.bufferCount
         }
-        self.appInfoOutput = (try? await appInfoResponse)?.response
-        self.bootloader = try? await bootloaderInfo.bootloader
-        self.bootloaderMode = try? await bootloaderInfo.mode
-        self.bootloaderSlot = try? await bootloaderInfo.slot
+        info.appInfoOutput = (try? await appInfoResponse)?.response
+        info.bootloader = try? await bootloaderInfo.bootloader
+        info.bootloaderMode = try? await bootloaderInfo.mode
+        info.bootloaderSlot = try? await bootloaderInfo.slot
+        return info
     }
     
     // MARK: requestOTAStatus
     
-    func requestOTAStatus(for peripheralUUID: UUID) async {
+    func requestOTAStatus(for peripheralUUID: UUID) async -> OTAStatus {
         let deviceInfoManager = DeviceInfoManager(peripheralUUID)
         do {
             let tokens = try await requestTokensViaMemfaultManager()
-            otaStatus = .supported(tokens.0, tokens.1)
+            return .supported(tokens.0, tokens.1)
         } catch {
             // Disregard error. Try again through Device Information.
             var deviceInfo: DeviceInfoToken!
             do {
                 deviceInfo = try await deviceInfoManager.getDeviceInfoToken()
                 let projectKey = try await deviceInfoManager.getProjectKey()
-                otaStatus = .supported(deviceInfo, projectKey)
+                return .supported(deviceInfo, projectKey)
             } catch let managerError as DeviceInfoManagerError {
                 if deviceInfo != nil {
-                    otaStatus = .missingProjectKey(deviceInfo, managerError)
+                    return .missingProjectKey(deviceInfo, managerError)
                 } else {
-                    otaStatus = .unsupported(managerError)
+                    return .unsupported(managerError)
                 }
             } catch let error {
-                otaStatus = .unsupported(error)
+                return .unsupported(error)
             }
         }
     }
@@ -107,18 +99,26 @@ fileprivate extension DeviceStatusManager {
     }
 }
 
+// MARK: - DeviceStatusInfo
+
+struct DeviceStatusInfo {
+    
+    var bufferCount: UInt64?
+    var bufferSize: UInt64?
+    var appInfoOutput: String?
+    var bootloader: BootloaderInfoResponse.Bootloader?
+    var bootloaderMode: BootloaderInfoResponse.Mode?
+    var bootloaderSlot: UInt64?
+}
+
 // MARK: - Delegate
 
 extension DeviceStatusManager {
     
     protocol Delegate: AnyObject {
         
+        func statusInfoDidChange(_ info: DeviceStatusInfo)
         func connectionStateDidChange(_ state: PeripheralState)
-        func bootloaderNameReceived(_ name: String)
-        func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode)
-        func bootloaderSlotReceived(_ slot: UInt64)
-        func appInfoReceived(_ output: String)
-        func mcuMgrParamsReceived(buffers: Int, size: Int)
         func otaStatusChanged(_ status: OTAStatus)
         func observabilityStatusChanged(_ status: ObservabilityStatus, pendingCount: Int, pendingBytes: Int, uploadedCount: Int, uploadedBytes: Int)
     }

--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -54,20 +54,8 @@ final class BaseViewController: UITabBarController {
             if let peripheralState {
                 deviceStatusDelegate?.connectionStateDidChange(peripheralState)
             }
-            if let bootloader {
-                deviceStatusDelegate?.bootloaderNameReceived(bootloader.description)
-            }
-            if let bootloaderMode {
-                deviceStatusDelegate?.bootloaderModeReceived(bootloaderMode)
-            }
-            if let bootloaderSlot {
-                deviceStatusDelegate?.bootloaderSlotReceived(bootloaderSlot)
-            }
-            if let appInfoOutput {
-                deviceStatusDelegate?.appInfoReceived(appInfoOutput)
-            }
-            if let mcuMgrParams {
-                deviceStatusDelegate?.mcuMgrParamsReceived(buffers: mcuMgrParams.bufferCount, size: mcuMgrParams.bufferSize)
+            if let statusInfo {
+                deviceStatusDelegate?.statusInfoDidChange(statusInfo)
             }
             if let otaStatus {
                 deviceStatusDelegate?.otaStatusChanged(otaStatus)
@@ -114,39 +102,10 @@ final class BaseViewController: UITabBarController {
         }
     }
     
-    private var bootloader: BootloaderInfoResponse.Bootloader? {
+    private var statusInfo: DeviceStatusInfo? {
         didSet {
-            guard let bootloader else { return }
-            deviceStatusDelegate?.bootloaderNameReceived(bootloader.description)
-        }
-    }
-    
-    private var bootloaderMode: BootloaderInfoResponse.Mode? {
-        didSet {
-            if let bootloaderMode {
-                deviceStatusDelegate?.bootloaderModeReceived(bootloaderMode)
-            }
-        }
-    }
-    
-    private var bootloaderSlot: UInt64? {
-        didSet {
-            guard let bootloaderSlot else { return }
-            deviceStatusDelegate?.bootloaderSlotReceived(bootloaderSlot)
-        }
-    }
-    
-    private var appInfoOutput: String? {
-        didSet {
-            guard let appInfoOutput else { return }
-            deviceStatusDelegate?.appInfoReceived(appInfoOutput)
-        }
-    }
-    
-    private var mcuMgrParams: (bufferCount: Int, bufferSize: Int)? {
-        didSet {
-            guard let mcuMgrParams else { return }
-            deviceStatusDelegate?.mcuMgrParamsReceived(buffers: mcuMgrParams.bufferCount, size: mcuMgrParams.bufferSize)
+            guard let statusInfo else { return }
+            deviceStatusDelegate?.statusInfoDidChange(statusInfo)
         }
     }
     
@@ -220,23 +179,13 @@ extension BaseViewController {
         guard let deviceStatusManager else { return }
         
         Task { @MainActor in
-            await deviceStatusManager.requestStatus()
-            
-            if let bufferSize = deviceStatusManager.bufferSize,
-                let bufferCount = deviceStatusManager.bufferCount {
-                mcuMgrParams = (Int(bufferSize), Int(bufferCount))
-            }
-            appInfoOutput = deviceStatusManager.appInfoOutput
-            bootloader = deviceStatusManager.bootloader
-            bootloaderMode = deviceStatusManager.bootloaderMode
-            bootloaderSlot = deviceStatusManager.bootloaderSlot
+            statusInfo = await deviceStatusManager.requestStatusInfo()
             
             guard let peripheral = peripheral?.basePeripheral else {
                 onDeviceStatusFinished()
                 return
             }
-            await deviceStatusManager.requestOTAStatus(for: peripheral.identifier)
-            otaStatus = deviceStatusManager.otaStatus
+            otaStatus = await deviceStatusManager.requestOTAStatus(for: peripheral.identifier)
             onDeviceStatusFinished()
         }
     }

--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -146,28 +146,24 @@ class DeviceController: UITableViewController, UITextFieldDelegate {
 
 extension DeviceController: DeviceStatusManager.Delegate {
     
+    func statusInfoDidChange(_ info: DeviceStatusInfo) {
+        if let buffers = info.bufferCount, let size = info.bufferSize {
+            mcuMgrParams.text = "\(buffers) x \(size) bytes"
+        }
+        if let appInfo = info.appInfoOutput {
+            kernel.text = appInfo
+        }
+        bootloaderName.text = (info.bootloader ?? .unknown).description
+        if let mode = info.bootloaderMode {
+            bootloaderMode.text = mode.description
+        }
+        if let slot = info.bootloaderSlot {
+            bootloaderSlot.text = "\(slot)"
+        }
+    }
+    
     func connectionStateDidChange(_ state: PeripheralState) {
         connectionStatus.text = state.description
-    }
-    
-    func bootloaderNameReceived(_ name: String) {
-        bootloaderName.text = name
-    }
-    
-    func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode) {
-        bootloaderMode.text = mode.description
-    }
-    
-    func bootloaderSlotReceived(_ slot: UInt64) {
-        bootloaderSlot.text = "\(slot)"
-    }
-    
-    func appInfoReceived(_ output: String) {
-        kernel.text = output
-    }
-    
-    func mcuMgrParamsReceived(buffers: Int, size: Int) {
-        mcuMgrParams.text = "\(buffers) x \(size) bytes"
     }
     
     func otaStatusChanged(_ status: OTAStatus) {

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -186,24 +186,20 @@ extension DiagnosticsController: DeviceStatusManager.Delegate {
         connectionStatus.text = state.description
     }
     
-    func bootloaderNameReceived(_ name: String) {
-        bootloaderName.text = name
-    }
-    
-    func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode) {
-        bootloaderMode.text = mode.description
-    }
-    
-    func bootloaderSlotReceived(_ slot: UInt64) {
-        bootloaderSlot.text = "\(slot)"
-    }
-    
-    func appInfoReceived(_ output: String) {
-        kernel.text = output
-    }
-    
-    func mcuMgrParamsReceived(buffers: Int, size: Int) {
-        mcuMgrParams.text = "\(buffers) x \(size) bytes"
+    func statusInfoDidChange(_ info: DeviceStatusInfo) {
+        if let buffers = info.bufferCount, let size = info.bufferSize {
+            mcuMgrParams.text = "\(buffers) x \(size) bytes"
+        }
+        if let appInfo = info.appInfoOutput {
+            kernel.text = appInfo
+        }
+        bootloaderName.text = (info.bootloader ?? .unknown).description
+        if let mode = info.bootloaderMode {
+            bootloaderMode.text = mode.description
+        }
+        if let slot = info.bootloaderSlot {
+            bootloaderSlot.text = "\(slot)"
+        }
     }
     
     func otaStatusChanged(_ status: OTAStatus) {

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -110,24 +110,20 @@ extension FilesController: DeviceStatusManager.Delegate {
         connectionStatus.text = state.description
     }
     
-    func bootloaderNameReceived(_ name: String) {
-        bootloaderName.text = name
-    }
-    
-    func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode) {
-        bootloaderMode.text = mode.description
-    }
-    
-    func bootloaderSlotReceived(_ slot: UInt64) {
-        bootloaderSlot.text = "\(slot)"
-    }
-    
-    func appInfoReceived(_ output: String) {
-        kernel.text = output
-    }
-    
-    func mcuMgrParamsReceived(buffers: Int, size: Int) {
-        mcuMgrParams.text = "\(buffers) x \(size) bytes"
+    func statusInfoDidChange(_ info: DeviceStatusInfo) {
+        if let buffers = info.bufferCount, let size = info.bufferSize {
+            mcuMgrParams.text = "\(buffers) x \(size) bytes"
+        }
+        if let appInfo = info.appInfoOutput {
+            kernel.text = appInfo
+        }
+        bootloaderName.text = (info.bootloader ?? .unknown).description
+        if let mode = info.bootloaderMode {
+            bootloaderMode.text = mode.description
+        }
+        if let slot = info.bootloaderSlot {
+            bootloaderSlot.text = "\(slot)"
+        }
     }
     
     func otaStatusChanged(_ status: OTAStatus) {

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -126,24 +126,20 @@ extension ImageController: DeviceStatusManager.Delegate {
         connectionStatus.text = state.description
     }
     
-    func bootloaderNameReceived(_ name: String) {
-        bootloaderName.text = name
-    }
-    
-    func bootloaderModeReceived(_ mode: BootloaderInfoResponse.Mode) {
-        bootloaderMode.text = mode.description
-    }
-    
-    func bootloaderSlotReceived(_ slot: UInt64) {
-        bootloaderSlot.text = "\(slot)"
-    }
-    
-    func appInfoReceived(_ output: String) {
-        kernel.text = output
-    }
-    
-    func mcuMgrParamsReceived(buffers: Int, size: Int) {
-        mcuMgrParams.text = "\(buffers) x \(size) bytes"
+    func statusInfoDidChange(_ info: DeviceStatusInfo) {
+        if let buffers = info.bufferCount, let size = info.bufferSize {
+            mcuMgrParams.text = "\(buffers) x \(size) bytes"
+        }
+        if let appInfo = info.appInfoOutput {
+            kernel.text = appInfo
+        }
+        bootloaderName.text = (info.bootloader ?? .unknown).description
+        if let mode = info.bootloaderMode {
+            bootloaderMode.text = mode.description
+        }
+        if let slot = info.bootloaderSlot {
+            bootloaderSlot.text = "\(slot)"
+        }
     }
     
     func otaStatusChanged(_ status: OTAStatus) {


### PR DESCRIPTION
Instead of multiple API calls to set multiple things, there's now one call. Granted, some other things still have other API calls but, this is a step that simplifies a lot of glue code. There are mostly SwiftUI-informed decisions here but, they do make the existing code better as well while we're on it.