### PR TITLE
Fix for Swift Concurrency not being available

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
@@ -11,6 +11,7 @@ import iOSMcuManagerLibrary
 
 // MARK: - DefaultManager+Async
 
+@available(iOS 13.0, macCatalyst 13.0, macOS 10.15, *)
 public extension DefaultManager {
     
     // MARK: async params()


### PR DESCRIPTION
I didn't even think about this because iOSOtaLibrary has async calls and they're not causing trouble, but of course, those aren't being pushed via Cocoapods.