### PR TITLE
Fixed CocoaPods Mac OS Deployment Target

### DIFF
--- a/iOSMcuManagerLibrary.podspec
+++ b/iOSMcuManagerLibrary.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.swift_versions = ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10"]
 
   s.ios.deployment_target = "13.0"
-  s.osx.deployment_target = "10.14"
+  s.osx.deployment_target = "10.15"
 
   s.source_files = "iOSMcuManagerLibrary/Source/**/*.{swift, h}"
   s.exclude_files = "iOSMcuManagerLibrary/Source/*.plist"


### PR DESCRIPTION
It should be set to 10.15, not 10.14. Some of the CocoaPods trunk push errors make sense now, in that they were not caused by Xcode but by the cocoapods utility. Anyway, 9 more months to go.