### PR TITLE
Set Default Actor Isolation to MainActor

### DIFF
--- a/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 				MARKETING_VERSION = 1.14.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nordicsemi.nrfconnect.devicemanager;
 				PRODUCT_NAME = "nRF Connect Device Manager";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -548,6 +549,7 @@
 				MARKETING_VERSION = 1.14.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nordicsemi.nrfconnect.devicemanager;
 				PRODUCT_NAME = "nRF Connect Device Manager";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};


### PR DESCRIPTION
This is one of those things that is, how my brain thought things worked before. But now they do, or they can if we have this enabled. There isn't a lot of Structured Concurrency going around in this project yet, so it's a move for the future. But why not?