### PR TITLE
Allow clients to override image magic numbers before OTA

### DIFF
--- a/iOSMcuManagerLibrary/Source/McuMgrImage.swift
+++ b/iOSMcuManagerLibrary/Source/McuMgrImage.swift
@@ -11,6 +11,21 @@ import Foundation
 public class McuMgrImage {
     
     public static let IMG_HASH_LEN = 32
+
+    /// Override the magic numbers used during image parsing.
+    /// Call this before initiating the first Device OTA if your firmware
+    /// uses non-standard magic values.
+    public static func setMagicNumbers(
+        tlvInfoMagic: UInt16 = McuMgrImageTlv.IMG_TLV_UNPROTECTED_INFO_MAGIC,
+        tlvProtectedInfoMagic: UInt16 = McuMgrImageTlv.IMG_TLV_PROTECTED_INFO_MAGIC,
+        headerMagicV1: UInt32 = McuMgrImageHeader.IMG_HEADER_MAGIC_V1,
+        headerMagic: UInt32 = McuMgrImageHeader.IMG_HEADER_MAGIC
+    ) {
+        McuMgrImageTlv.IMG_TLV_UNPROTECTED_INFO_MAGIC = tlvInfoMagic
+        McuMgrImageTlv.IMG_TLV_PROTECTED_INFO_MAGIC = tlvProtectedInfoMagic
+        McuMgrImageHeader.IMG_HEADER_MAGIC_V1 = headerMagicV1
+        McuMgrImageHeader.IMG_HEADER_MAGIC = headerMagic
+    }
     
     public let header: McuMgrImageHeader
     public let tlv: McuMgrImageTlv
@@ -41,8 +56,8 @@ public class McuMgrImageHeader {
     
     public static let IMG_HEADER_LEN = 24
     
-    public static let IMG_HEADER_MAGIC: UInt32 = 0x96f3b83d
-    public static let IMG_HEADER_MAGIC_V1: UInt32 = 0x96f3b83c
+    public static var IMG_HEADER_MAGIC: UInt32 = 0x96f3b83d
+    public static var IMG_HEADER_MAGIC_V1: UInt32 = 0x96f3b83c
     
     public static let MAGIC_OFFSET = 0
     public static let LOAD_ADDR_OFFSET = 4
@@ -118,8 +133,8 @@ public struct McuMgrImageTlv {
     public static let IMG_TLV_ENC_EC256: UInt8 = 0x32
     public static let IMG_TLV_DEPENDENCY = 0x40
     
-    public static let IMG_TLV_UNPROTECTED_INFO_MAGIC: UInt16 = 0x6907
-    public static let IMG_TLV_PROTECTED_INFO_MAGIC: UInt16 = 0x6908
+    public static var IMG_TLV_UNPROTECTED_INFO_MAGIC: UInt16 = 0x6907
+    public static var IMG_TLV_PROTECTED_INFO_MAGIC: UInt16 = 0x6908
     
     public var tlvInfo: McuMgrImageTlvInfo?
     public var trailerTlvEntries: [McuMgrImageTlvTrailerEntry]


### PR DESCRIPTION
Background
McuMgrImage parses firmware images by comparing magic numbers in the image header and TLV info against four hardcoded constants:

Constant	Location	Default
IMG_HEADER_MAGIC	McuMgrImageHeader	0x96f3b83d
IMG_HEADER_MAGIC_V1	McuMgrImageHeader	0x96f3b83c
IMG_TLV_UNPROTECTED_INFO_MAGIC	McuMgrImageTlv	0x6907
IMG_TLV_PROTECTED_INFO_MAGIC	McuMgrImageTlv	0x6908
These match the standard MCUboot values. However, some firmware builds use custom magic numbers, causing McuMgrImageParseError.invalidHeaderMagic or invalidTlvInfoMagic on otherwise valid images.

Changes
Changed the four magic number constants from static let to static var so they can be updated at runtime.
Added McuMgrImage.setMagicNumbers(...) — a public static method with all four parameters optional (defaulting to the standard MCUboot values).  
Usage
Only the values that differ from the standard need to be passed; the rest retain their defaults.

Notes
No existing API or behaviour is changed. Default values are identical to the previous hardcoded constants.
The override is process-global (static state), intended to be set once before OTA begins. 