### PR TITLE
Fix for correctly parsed Load Address set to zero

### DIFF
--- a/iOSMcuManagerLibrary/Source/McuMgrManifest.swift
+++ b/iOSMcuManagerLibrary/Source/McuMgrManifest.swift
@@ -143,16 +143,16 @@ extension McuMgrManifest {
             }
             
             let loadAddressString: String? = try? values.decode(String.self, forKey: .loadAddress)
-            let loadAddressInt: Int
+            let loadAddressInt: Int?
             if let loadAddressString {
-                loadAddressInt = Int(loadAddressString) ?? .zero
+                loadAddressInt = Int(loadAddressString)
             } else {
-                loadAddressInt = (try? values.decode(Int.self, forKey: .loadAddress)) ?? .zero
+                loadAddressInt = try? values.decode(Int.self, forKey: .loadAddress)
             }
             
-            // Load Address is an MCUBoot Manifest "requirement".
-            // For SUIT it's not set, but we keep it at zero for backwards compatibility.
-            loadAddress = bootloader == .mcuboot ? loadAddressInt : .zero
+            // Note: Load Address presence is an MCUBoot Manifest "requirement".
+            // For SUIT it's not set, but set it at zero for backwards compatibility.
+            loadAddress = loadAddressInt ?? .zero
             
             if let partitionString = try? values.decode(String.self, forKey: ._partition) {
                 _partition = Int(partitionString)


### PR DESCRIPTION
We parse the value correctly. But we only set it if the "type" of application was listed as "mcuboot". Now, 53 images for example are now listed as "application" instead of "mcuboot". So, we switched to setting the value of the load address if we parse it successfully, and if not, we set it to zero to not break anything. Like nRF Connect's Preview, our canary in the coal mine.