### PR TITLE
Defensive Programming: Crash against using FirmwareUpgradeManager as Delegate

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -1141,10 +1141,10 @@ internal extension FirmwareUpgradeManager {
 extension FirmwareUpgradeManager: ImageUploadDelegate {
     
     public func uploadProgressDidChange(bytesSent: Int, imageSize: Int, timestamp: Date) {
-        if bytesSent == imageSize {
+        if bytesSent == imageSize, var images {
             // An Image was sent. Mark as uploaded.
-            if let image = self.images.first(where: { !$0.uploaded && $0.data.count == imageSize }) {
-                self.mark(image, as: \.uploaded)
+            if let image = images.first(where: { !$0.uploaded && $0.data.count == imageSize }) {
+                mark(image, as: \.uploaded)
             }
         }
         


### PR DESCRIPTION
This was spurned by er, not incorrect but, unexpected, use of FirmwareUpgradeManager as a 'Delegate' for ImageManager, which was sparked by chasing down customer feedback on GitHub. I don't think this is a fix for anything but, in the off-chance a customer encounters this issue, because we did, better to have it fixed if we can make our customer's lives easier. Where we can.