### PR TITLE
Unowned self for McuMgrBleTransport send / enqueue Operation

### DIFF
--- a/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
@@ -247,7 +247,7 @@ extension McuMgrBleTransport: McuMgrTransport {
     }
     
     public func send<T: McuMgrResponse>(data: Data, timeout: Int, callback: @escaping McuMgrCallback<T>) {
-        operationQueue.addOperation {
+        operationQueue.addOperation { [unowned self] in
             for i in 0..<McuMgrBleTransportConstant.MAX_RETRIES {
                 switch self._send(data: data, timeoutInSeconds: timeout) {
                 case .failure(McuMgrTransportError.waitAndRetry):
@@ -258,6 +258,7 @@ extension McuMgrBleTransport: McuMgrTransport {
                     } else {
                         self.log(msg: "Retry \(i + 1) (Unknown Header Type)", atLevel: .info)
                     }
+                    continue // retry
                 case .failure(McuMgrTransportError.peripheralNotReadyForWriteWithoutResponse):
                     if let header = try? McuMgrHeader(data: data) {
                         self.log(msg: "(Retry \(i + 1)) Peripheral not ready for write without response. Attempting to wait or send seq: \(header.sequenceNumber)", atLevel: .debug)


### PR DESCRIPTION
Seems like the obvious thing, since the Transport should outlive its Bluetooth LE operations / commands But I guess this might expose hidden issues. In theory it's also a potential fix for a memory cycle or leak, but I worry more about things breaking. Anyway, hopefully when things break we'll remember it can be due to this change. Even though if we do catch those issues, in the end it should be better in the long run.