### PR TITLE
Marked McuMgrManifest init as nonisolated

### DIFF
--- a/iOSMcuManagerLibrary/Source/McuMgrManifest.swift
+++ b/iOSMcuManagerLibrary/Source/McuMgrManifest.swift
@@ -27,8 +27,9 @@ public struct McuMgrManifest: Codable {
     static let LoadAddressRegEx: NSRegularExpression! =
         try? NSRegularExpression(pattern: #"\"load_address\":0x[0-9a-z]+,"#, options: [.caseInsensitive])
     
-    // MARK: Init
+    // MARK: init
     
+    nonisolated
     public init(from url: URL) throws {
         guard let data = try? Data(contentsOf: url),
               let stringData = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
This is mostly a small development stemming from us trying to invest more time in understanding Swift Concurrency and how it can be used to improve performance from the user's perspective and, being able to decide where code runs from is a big part of it.