### PR TITLE
Change: BaseViewController is no longer defined in the Storyboard

### DIFF
--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -633,21 +633,6 @@
             </objects>
             <point key="canvasLocation" x="2350" y="-479"/>
         </scene>
-        <!--Base View Controller-->
-        <scene sceneID="kvH-Bp-M1y">
-            <objects>
-                <tabBarController storyboardIdentifier="baseVC" id="1dQ-jk-NPB" customClass="BaseViewController" customModule="nRF_Connect_Device_Manager" customModuleProvider="target" sceneMemberID="viewController">
-                    <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="TcB-Y8-CRY">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <color key="barTintColor" systemColor="secondarySystemBackgroundColor"/>
-                    </tabBar>
-                </tabBarController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="d5b-LC-i65" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1430" y="254"/>
-        </scene>
         <!--Image-->
         <scene sceneID="URt-ni-pll">
             <objects>
@@ -2581,7 +2566,7 @@
         <scene sceneID="OqD-0B-QPm">
             <objects>
                 <viewController title="Upload" id="ZG1-GB-bgc" customClass="FileUploadViewController" customModule="nRF_Connect_Device_Manager" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="yVO-JE-3UU">
+                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="yVO-JE-3UU">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="271"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -2987,9 +2972,6 @@
         </systemColor>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="secondarySystemBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="separatorColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.12" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -71,13 +71,22 @@ final class BaseViewController: UITabBarController {
      */
     var transport: McuMgrTransport!
     
-    var peripheral: DiscoveredPeripheral! {
-        didSet {
-            let bleTransport = McuMgrBleTransport(peripheral.basePeripheral)
-            bleTransport.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
-            bleTransport.delegate = self
-            transport = bleTransport
-        }
+    var peripheral: DiscoveredPeripheral!
+    
+    // MARK: init
+    
+    init(_ peripheral: DiscoveredPeripheral) {
+        let bleTransport = McuMgrBleTransport(peripheral.basePeripheral)
+        bleTransport.logDelegate = UIApplication.shared.delegate as? McuMgrLogDelegate
+        transport = bleTransport
+        self.peripheral = peripheral
+        super.init(nibName: nil, bundle: nil)
+        
+        (transport as? McuMgrBleTransport)?.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: Private Properties

--- a/Example/Example/View Controllers/Scanner/ScannerViewController.swift
+++ b/Example/Example/View Controllers/Scanner/ScannerViewController.swift
@@ -169,10 +169,7 @@ final class ScannerViewController: UITableViewController, CBCentralManagerDelega
         centralManager.stopScan()
         activityIndicator.stopAnimating()
         
-        let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
-        guard let baseViewController = storyboard.instantiateViewController(identifier: "baseVC") as? BaseViewController else { return }
-        
-        baseViewController.peripheral = filteredPeripherals[indexPath.row]
+        let baseViewController = BaseViewController(filteredPeripherals[indexPath.row])
         navigationController?.pushViewController(baseViewController, animated: true)
     }
     


### PR DESCRIPTION
It is now fully programmatic. This has the positive consequence of the transport now being defined where it should be, which is in the init, because it's a requirement, or dependency in SwiftUI terms, for the BaseViewController to be able to do its job.