### PR TITLE
Change: ScannerViewController's NavBar Items are now defined programmatically

### DIFF
--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -201,32 +201,8 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Device Manager" id="JgL-aj-vMP">
                         <barButtonItem key="backBarButtonItem" title="Scanner" id="XAL-Mr-ksZ"/>
-                        <rightBarButtonItems>
-                            <barButtonItem title="About" id="aWy-Ct-4js">
-                                <connections>
-                                    <action selector="aboutTapped:" destination="brr-jW-Ynb" id="gBH-Vq-fZn"/>
-                                </connections>
-                            </barButtonItem>
-                            <barButtonItem id="9n2-3j-DCY">
-                                <view key="customView" contentMode="scaleToFill" id="X9s-eL-VOJ">
-                                    <rect key="frame" x="180.66666666666666" y="4.0000000000000009" width="82.999999999999972" height="36"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <subviews>
-                                        <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="X3v-MD-Kn9">
-                                            <rect key="frame" x="47" y="8" width="20" height="20"/>
-                                        </activityIndicatorView>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="X3v-MD-Kn9" secondAttribute="trailing" constant="16" id="Awa-yx-ax6"/>
-                                        <constraint firstItem="X3v-MD-Kn9" firstAttribute="centerY" secondItem="X9s-eL-VOJ" secondAttribute="centerY" id="FiM-5k-1qL"/>
-                                    </constraints>
-                                </view>
-                            </barButtonItem>
-                        </rightBarButtonItems>
                     </navigationItem>
                     <connections>
-                        <outlet property="activityIndicator" destination="X3v-MD-Kn9" id="8Yg-MV-JhD"/>
                         <outlet property="emptyPeripheralsView" destination="7nf-Dp-LTI" id="jIn-r0-Jql"/>
                     </connections>
                 </tableViewController>

--- a/Example/Example/View Controllers/Scanner/ScannerViewController.swift
+++ b/Example/Example/View Controllers/Scanner/ScannerViewController.swift
@@ -15,7 +15,6 @@ final class ScannerViewController: UITableViewController, CBCentralManagerDelega
     // MARK: @IBOutlet(s)
     
     @IBOutlet weak var emptyPeripheralsView: UIView!
-    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     
     // MARK: Private Properties
     
@@ -24,15 +23,10 @@ final class ScannerViewController: UITableViewController, CBCentralManagerDelega
     private var discoveredPeripherals = [DiscoveredPeripheral]()
     private var filteredPeripherals = [DiscoveredPeripheral]()
     
+    private lazy var activityIndicator = UIActivityIndicatorView()
+    
     private var filterByName: Bool!
     private var filterByRssi: Bool!
-    
-    // MARK: aboutTapped
-    
-    @IBAction func aboutTapped(_ sender: UIBarButtonItem) {
-        let rootViewController = navigationController as? RootViewController
-        rootViewController?.showIntro(animated: true)
-    }
     
     // MARK: onFilterTapped
     
@@ -49,6 +43,13 @@ final class ScannerViewController: UITableViewController, CBCentralManagerDelega
         filterController.popoverPresentationController?.permittedArrowDirections = [.any]
         filterController.popoverPresentationController?.barButtonItem = sender
         present(filterController, animated: true)
+    }
+    
+    // MARK: onInfoTapped
+    
+    @objc func onInfoTapped(_ sender: UIBarButtonItem) {
+        let rootViewController = navigationController as? RootViewController
+        rootViewController?.showIntro(animated: true)
     }
     
     // MARK: viewDidLoad
@@ -73,6 +74,10 @@ final class ScannerViewController: UITableViewController, CBCentralManagerDelega
         tableView.reloadData()
         
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "switch.2"), style: .plain, target: self, action: #selector(onFilterTapped(_:)))
+        
+        let activityBarButtonItem = UIBarButtonItem(customView: activityIndicator)
+        let infoBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "info"), style: .plain, target: self, action: #selector(onInfoTapped(_:)))
+        navigationItem.rightBarButtonItems = [infoBarButtonItem, activityBarButtonItem]
         
         guard pullToRefreshControl == nil else { return }
         pullToRefreshControl = UIRefreshControl()


### PR DESCRIPTION
This includes the Activity Indicator as well, which I was not planning to do. But when adding the info button we overstepped into the Activity Indicator set in the Storyboard, so we had to do both. I don't know if this serves as a relearning experience or as a historical record of how UIKit used to work before. But the great thing about how UIKit used to work before, is that it worked. It was consistent and fast, unlike SwiftUI... sometimes.