### PR TITLE
Use of CoreBluetoothMock for Simulator usage

### DIFF
--- a/Example/Example/View Controllers/Scanner/ScannerViewController.swift
+++ b/Example/Example/View Controllers/Scanner/ScannerViewController.swift
@@ -86,8 +86,7 @@ final class ScannerViewController: UITableViewController, CBMCentralManagerDeleg
         super.viewDidLoad()
         title = "Device Manager"
         
-        centralManager = CBMCentralManagerFactory.instance(delegate: self, queue: .main,
-                                                          forceMock: false)
+        centralManager = CBMCentralManagerFactory.instance(delegate: self, queue: .main)
         centralManager.delegate = self
         
         // Default to true to filter devices by name
@@ -95,6 +94,14 @@ final class ScannerViewController: UITableViewController, CBMCentralManagerDeleg
         filterByRssi = UserDefaults.standard.bool(forKey: "filterByRssi")
         
         tableView.register(ScannerTableViewCell.self, forCellReuseIdentifier: ScannerTableViewCell.reuseIdentifier)
+        
+        #if targetEnvironment(simulator)
+        CBMCentralManagerMock.simulateInitialState(.poweredOn)
+        let uart = UART()
+        CBMCentralManagerMock.simulatePeripherals([
+            uart.spec,
+        ])
+        #endif
     }
     
     // MARK: viewWillAppear

--- a/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
+++ b/Example/nRF Connect Device Manager.xcodeproj/project.pbxproj
@@ -601,8 +601,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nordicsemi/IOS-CoreBluetooth-Mock.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.5;
+				branch = main;
+				kind = branch;
 			};
 		};
 		AAC0F0322E670D38006E0ADD /* XCRemoteSwiftPackageReference "IOS-nRF-Connect-Device-Manager" */ = {


### PR DESCRIPTION
There's a single Mock for now, for UART. But we got it show up, so we can open the 'Device' screen from the Simulator and test the UI. Even though we don't have a full mock setup because the McuMgrBleTransport has its own Peripheral and so on.