### PR TITLE
Added Blinky Mock on the Simulator as well

### DIFF
--- a/Example/Example/View Controllers/Scanner/ScannerViewController.swift
+++ b/Example/Example/View Controllers/Scanner/ScannerViewController.swift
@@ -98,8 +98,10 @@ final class ScannerViewController: UITableViewController, CBMCentralManagerDeleg
         #if targetEnvironment(simulator)
         CBMCentralManagerMock.simulateInitialState(.poweredOn)
         let uart = UART()
+        let blinky = Blinky()
         CBMCentralManagerMock.simulatePeripherals([
             uart.spec,
+            blinky.spec
         ])
         #endif
     }


### PR DESCRIPTION
Again, it doesn't add much other than give us two potential devices on the Simulator. Since the McuMgrBleTransport looks for the device on its own, but again, for UI testing this should be useful.