### PR TITLE
Fixed Reset into Firmware Loader Placeholder

### DIFF
--- a/Example/Example/View Controllers/Manager/ResetViewController.swift
+++ b/Example/Example/View Controllers/Manager/ResetViewController.swift
@@ -61,7 +61,7 @@ final class ResetViewController: UIViewController, McuMgrViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         firmwareLoaderToggleChanged(switchToFirmwareLoaderToggle)
         
-        advertisingNameTextField.placeholder = "Defaults to 'fl_[HH]_[mm]'"
+        advertisingNameTextField.placeholder = "Defaults to 'FL_[HH][mm][ss]'"
     }
     
     // MARK: callReset(mode:)


### PR DESCRIPTION
The placeholder text was wrong, which might seem like a very small thing, but when you're trying to decide whether you did the wrong thing or the app did the wrong thing or the text is wrong, it helps to fix the last and put it to rest.