### PR TITLE
Added async variant of DefaultManager's reset()

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
@@ -14,8 +14,29 @@ import iOSMcuManagerLibrary
 @available(iOS 13.0, macCatalyst 13.0, macOS 10.15, *)
 public extension DefaultManager {
     
+    // MARK: async reset(bootMode:force:)
+    
+    /// Async variant of ``reset(bootMode:force:callback:)``
+    public func reset(bootMode: ResetBootMode = .normal, force: Bool = false) async throws -> McuMgrResponse {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
+            reset(bootMode: bootMode, force: force) { response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let response {
+                    continuation.resume(returning: response)
+                } else {
+                    continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
+                }
+            }
+        }
+    }
+    
     // MARK: async params()
     
+    /// Async variant of ``params(callback:)``
     public func params() async throws -> McuMgrParametersResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrParametersResponse, Error>) in
             params { response, error in
@@ -35,6 +56,7 @@ public extension DefaultManager {
     
     // MARK: async applicationInfo(format:)
     
+    /// Async variant of ``applicationInfo(format:callback:)``
     public func applicationInfo(format: Set<ApplicationInfoFormat>) async throws -> AppInfoResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<AppInfoResponse, Error>) in
             applicationInfo(format: format) { response, error in
@@ -65,6 +87,7 @@ public extension DefaultManager {
     
     // MARK: bootloaderQuery(:)
     
+    /// Async variant of ``bootloaderInfo(query:callback:)``
     public func bootloaderQuery(_ query: BootloaderInfoQuery) async throws -> BootloaderInfoResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BootloaderInfoResponse, Error>) in
             bootloaderInfo(query: query) { response, error in

--- a/iOSMcuManagerLibrary/Source/Managers/StatsManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/StatsManager+Async.swift
@@ -15,6 +15,7 @@ public extension StatsManager {
     
     // MARK: async list()
     
+    /// Async variant of ``list(callback:)``
     public func list() async throws -> McuMgrStatsListResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrStatsListResponse, Error>) in
             list { response, error in
@@ -34,6 +35,7 @@ public extension StatsManager {
     
     // MARK: async read(module:)
     
+    /// Async variant of ``read(module:callback:)``
     public func read(module: String) async throws -> McuMgrStatsResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrStatsResponse, Error>) in
             read(module: module) { response, error in


### PR DESCRIPTION
So reset can be called / executed via Structured Concurrency. And some day, I don't know when, perhaps things are reverted and the callback API is the one that goes out. But not today.