### PR TITLE
Fix: Do not require SMP Service to report Observability

### DIFF
--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -27,8 +27,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="51"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Connection status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yZo-Ck-heo">
-                                                    <rect key="frame" x="16" y="15.999999999999998" width="138.66666666666666" height="20.333333333333332"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="SMP Service" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yZo-Ck-heo">
+                                                    <rect key="frame" x="15.999999999999993" y="15.999999999999998" width="96.333333333333329" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -355,11 +355,11 @@
                         <outlet property="bootloaderMode" destination="smW-QM-FfV" id="mA4-h1-ZYw"/>
                         <outlet property="bootloaderName" destination="uaI-gC-497" id="f38-2r-hlr"/>
                         <outlet property="bootloaderSlot" destination="Vby-ya-YD1" id="rrh-Sx-rHv"/>
-                        <outlet property="connectionStatus" destination="O3R-v7-4NX" id="yj7-St-r3t"/>
                         <outlet property="kernel" destination="gLO-Vy-wq7" id="l0u-T4-ia8"/>
                         <outlet property="mcuMgrParams" destination="XBY-MZ-p44" id="rmM-Jj-00v"/>
                         <outlet property="observabilityStatus" destination="ngs-um-OT5" id="uL0-Um-cfd"/>
                         <outlet property="otaStatusLabel" destination="hpN-ya-AfX" id="QHf-Dt-yFv"/>
+                        <outlet property="smpService" destination="O3R-v7-4NX" id="yj7-St-r3t"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6wy-pp-4s9" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Example/Example/State/DeviceStatusManager.swift
+++ b/Example/Example/State/DeviceStatusManager.swift
@@ -118,7 +118,7 @@ extension DeviceStatusManager {
     protocol Delegate: AnyObject {
         
         func statusInfoDidChange(_ info: DeviceStatusInfo)
-        func connectionStateDidChange(_ state: PeripheralState)
+        func transportStateDidChange(_ state: PeripheralState)
         func otaStatusChanged(_ status: OTAStatus)
         func observabilityStatusChanged(_ statusInfo: ObservabilityStatusInfo)
     }

--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -18,7 +18,7 @@ final class BaseViewController: UITabBarController {
     weak var deviceStatusDelegate: DeviceStatusManager.Delegate? {
         didSet {
             if let peripheralState {
-                deviceStatusDelegate?.connectionStateDidChange(peripheralState)
+                deviceStatusDelegate?.transportStateDidChange(peripheralState)
             }
             if let statusInfo {
                 deviceStatusDelegate?.statusInfoDidChange(statusInfo)
@@ -66,7 +66,7 @@ final class BaseViewController: UITabBarController {
     private var peripheralState: PeripheralState? {
         didSet {
             guard let peripheralState else { return }
-            deviceStatusDelegate?.connectionStateDidChange(peripheralState)
+            deviceStatusDelegate?.transportStateDidChange(peripheralState)
         }
     }
     
@@ -84,7 +84,12 @@ final class BaseViewController: UITabBarController {
         }
     }
     
-    private var observabilityStatusInfo: ObservabilityStatusInfo?
+    private var observabilityStatusInfo: ObservabilityStatusInfo? {
+        didSet {
+            guard let observabilityStatusInfo else { return }
+            deviceStatusDelegate?.observabilityStatusChanged(observabilityStatusInfo)
+        }
+    }
     
     // MARK: viewDidLoad()
     
@@ -144,7 +149,7 @@ final class BaseViewController: UITabBarController {
 // MARK: - DeviceStatusRow
 
 enum DeviceStatusRow: Int, RawRepresentable, CaseIterable, CustomStringConvertible {
-    case connection
+    case smpService
     case mcuMgrParameters
     case bootloaderName
     case bootloaderMode
@@ -155,8 +160,8 @@ enum DeviceStatusRow: Int, RawRepresentable, CaseIterable, CustomStringConvertib
     
     var description: String {
         switch self {
-        case .connection:
-            return "Connection Status"
+        case .smpService:
+            return "SMP Service"
         case .mcuMgrParameters:
             return "Buffer Details"
         case .bootloaderName:
@@ -197,7 +202,7 @@ extension BaseViewController {
     
     func update(_ cell: UITableViewCell, asDeviceStatusRow row: DeviceStatusRow?) {
         switch row {
-        case .connection:
+        case .smpService:
             cell.detailTextLabel?.text = peripheralState?.description
         case .mcuMgrParameters:
             if let buffers = statusInfo?.bufferCount, let size = statusInfo?.bufferSize {
@@ -343,8 +348,8 @@ extension BaseViewController {
         guard let statusRow = DeviceStatusRow(rawValue: indexPath.row) else { return }
         let helpDialogAlertController = UIAlertController(title: "\(statusRow) Help", message: nil, preferredStyle: .alert)
         switch statusRow {
-        case .connection:
-            helpDialogAlertController.message = "\nReports the status of the Bluetooth LE connection to the device."
+        case .smpService:
+            helpDialogAlertController.message = "\nReports the status of the SMP Service connection to the device."
         case .mcuMgrParameters:
             helpDialogAlertController.message = "\nNumber of MCU Manager buffers and their size. Requires MCU Mgr Parameters command in OS Group."
         case .bootloaderName:
@@ -400,6 +405,9 @@ extension BaseViewController {
 extension BaseViewController {
     
     func startObservability(for peripheral: CBPeripheral) {
+        guard observabilityStatusManager == nil else {
+            return // Already in Progress.
+        }
         let peripheralUUID = peripheral.identifier
         Task { @MainActor in
             observabilityStatusManager = ObservabilityStatusManager(peripheralIdentifier: peripheralUUID)
@@ -407,12 +415,11 @@ extension BaseViewController {
             print("\(#function): STARTED Listening to \(peripheralUUID) Observability Events.")
             for await statusInfo in stream {
                 observabilityStatusInfo = statusInfo
-                deviceStatusDelegate?.observabilityStatusChanged(statusInfo)
             }
             print("\(#function): STOPPED Listening to \(peripheralUUID) Observability Events.")
-            guard var observabilityStatusInfo else { return }
-            observabilityStatusInfo.updatedStatus(.connectionClosed)
-            deviceStatusDelegate?.observabilityStatusChanged(observabilityStatusInfo)
+            var connectionClosedStatus = observabilityStatusInfo
+            connectionClosedStatus?.updatedStatus(.connectionClosed)
+            observabilityStatusInfo = connectionClosedStatus
         }
     }
     
@@ -429,12 +436,14 @@ extension BaseViewController: PeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didChangeStateTo state: PeripheralState) {
         peripheralState = state
         switch state {
-        case .connected:
+        case .connecting:
+            // Don't wait for .connected because McuMgrBleTransport only sends 'connected'
+            // if SMP Service is found. Observability might still work because it relies
+            // on MDS Service Instead.
             startObservability(for: peripheral)
         case .disconnecting, .disconnected:
             // Set to false, because a DFU update might change things if that's what happened.
             deviceInfoRequested = false
-            stopObservability()
         default:
             // Nothing to do here.
             break

--- a/Example/Example/View Controllers/Manager/DeviceController.swift
+++ b/Example/Example/View Controllers/Manager/DeviceController.swift
@@ -342,7 +342,7 @@ extension DeviceController: DeviceStatusManager.Delegate {
         tableView.reloadSections(IndexSet([Section.deviceStatus.rawValue]), with: .none)
     }
     
-    func connectionStateDidChange(_ state: PeripheralState) {
+    func transportStateDidChange(_ state: PeripheralState) {
         tableView.reloadSections(IndexSet([Section.deviceStatus.rawValue]), with: .none)
     }
     

--- a/Example/Example/View Controllers/Manager/DiagnosticsController.swift
+++ b/Example/Example/View Controllers/Manager/DiagnosticsController.swift
@@ -384,7 +384,7 @@ private extension DiagnosticsController {
 
 extension DiagnosticsController: DeviceStatusManager.Delegate {
     
-    func connectionStateDidChange(_ state: PeripheralState) {
+    func transportStateDidChange(_ state: PeripheralState) {
         tableView.reloadSections(IndexSet([Section.deviceStatus.rawValue]), with: .none)
         // Reload in separate command, otherwise we get a 'blinking' header effect.
         tableView.reloadSections(IndexSet([Section.observability.rawValue]), with: .none)

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -266,7 +266,7 @@ final class FilesController: UITableViewController {
 
 extension FilesController: DeviceStatusManager.Delegate {
     
-    func connectionStateDidChange(_ state: PeripheralState) {
+    func transportStateDidChange(_ state: PeripheralState) {
         tableView.reloadSections(IndexSet([Section.deviceStatus.rawValue]), with: .none)
     }
     

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -13,7 +13,7 @@ final class ImageController: UITableViewController {
     
     // MARK: @IBOutlet(s)
     
-    @IBOutlet weak var connectionStatus: UILabel!
+    @IBOutlet weak var smpService: UILabel!
     @IBOutlet weak var mcuMgrParams: UILabel!
     @IBOutlet weak var bootloaderName: UILabel!
     @IBOutlet weak var bootloaderMode: UILabel!
@@ -122,8 +122,8 @@ final class ImageController: UITableViewController {
 
 extension ImageController: DeviceStatusManager.Delegate {
     
-    func connectionStateDidChange(_ state: PeripheralState) {
-        connectionStatus.text = state.description
+    func transportStateDidChange(_ state: PeripheralState) {
+        smpService.text = state.description
     }
     
     func statusInfoDidChange(_ info: DeviceStatusInfo) {


### PR DESCRIPTION
This was a client (nRF Connect Device Manager) side issue as there are no changes required in the library. Previously, we only started/attempted Observability after "connection", which is received when the underlying McuMgrBleTransport finds SMP Service. Now, we start Observability when the user attempts to connect to a Device, and we also no longer stop Observability on McuMgrBleTransport disconnection, because the transport can disconnect when SMP Service is not found and prevent Observability from reporting chunks. The other changes stem from adapting to this.