### PR TITLE
Fix for mismatched "Unknown" Device Status Value

### DIFF
--- a/Example/Example/View Controllers/Manager/BaseViewController.swift
+++ b/Example/Example/View Controllers/Manager/BaseViewController.swift
@@ -211,7 +211,11 @@ extension BaseViewController {
                 cell.detailTextLabel?.text = "UNKNOWN"
             }
         case .bootloaderName:
-            cell.detailTextLabel?.text = (statusInfo?.bootloader ?? .unknown).description
+            guard let bootloader = statusInfo?.bootloader, bootloader != .unknown else {
+                cell.detailTextLabel?.text = "UNKNOWN"
+                break
+            }
+            cell.detailTextLabel?.text = bootloader.description
         case .bootloaderMode:
             if let mode = statusInfo?.bootloaderMode {
                 cell.detailTextLabel?.text = mode.description

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -133,7 +133,11 @@ extension ImageController: DeviceStatusManager.Delegate {
         if let appInfo = info.appInfoOutput {
             kernel.text = appInfo
         }
-        bootloaderName.text = (info.bootloader ?? .unknown).description
+        if let bootloader = info.bootloader, bootloader != .unknown {
+            bootloaderName.text = bootloader.description
+        } else {
+            bootloaderName.text = "UNKNOWN"
+        }
         if let mode = info.bootloaderMode {
             bootloaderMode.text = mode.description
         }


### PR DESCRIPTION
Bootloader name read "Unknown" instead of "UNKOWN" as the rest of the app. The former is the returned value from the underlying iOSMcuMgrLibrary, so we'd rather not modify that just for us (nRF Connect Device Manager). So we took the opposite approach.