### PR TITLE
Fix: Detect CoreBluetooth "Peer removed pairing information" Error

### DIFF
--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
@@ -92,7 +92,11 @@ internal extension ObservabilityManager {
             deviceContinuations[identifier]?.yield(with: .failure(ObservabilityError.pairingError))
             deviceCancellables[identifier]?.removeAll()
         } catch {
-            deviceContinuations[identifier]?.yield(with: .failure(error))
+            if error.localizedDescription.localizedCaseInsensitiveContains("Peer removed pairing information") {
+                deviceContinuations[identifier]?.yield(with: .failure(ObservabilityError.pairingError))
+            } else {
+                deviceContinuations[identifier]?.yield(with: .failure(error))
+            }
             deviceCancellables[identifier]?.removeAll()
             // Is disconnect here necessary? It was not in Memfault-lib.
 //            disconnect(from: identifier)


### PR DESCRIPTION
This happens when the opposite device, henceknown as 'peer', has lost its own set of pairing keys. It's a different, but overall still an error at the Pairing stage, so we're reporting it as that. There was also no specific CBATTError that we could target, so I went for the less elegant solution. This same string seems to be there from the days of iOS 14 so, i'm hoping it's not modified.