### PR TITLE
Fix: Add catch for CBATTError.insufficientAuthentication as well

### DIFF
--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
@@ -88,7 +88,7 @@ internal extension ObservabilityManager {
             
             guard state.pendingChunks(for: identifier).hasItems else { return }
             resumeUploadsIfNotBusy(for: identifier, with: auth)
-        } catch CBATTError.insufficientEncryption {
+        } catch CBATTError.insufficientEncryption, CBATTError.insufficientAuthentication {
             deviceContinuations[identifier]?.yield(with: .failure(ObservabilityError.pairingError))
             deviceCancellables[identifier]?.removeAll()
         } catch {


### PR DESCRIPTION
This one is triggered by not pairing with a device for Observability, and reconnecting again. This second time, the error reported by CoreBluetooth will be the newly added one. And with this change, instead of 'ERROR' user will see the more accurate 'PAIRING ERROR' once again. Details matter. Details add up.