### PR TITLE
Change: FirmwareUpgradeState now conforms to CustomStringConvertible

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DFU/FirmwareUpgradeManager.swift
@@ -1265,12 +1265,43 @@ extension FirmwareUpgradeManager: SuitManagerDelegate {
 // MARK: - FirmwareUpgradeState
 //******************************************************************************
 
-public enum FirmwareUpgradeState {
+public enum FirmwareUpgradeState: CustomStringConvertible {
     case none
     case requestMcuMgrParameters, bootloaderInfo, eraseAppSettings
     case upload, success
     case validate, test, confirm, reset
     case resetIntoFirmwareLoader
+    
+    // MARK: description
+    
+    public var description: String {
+        switch self {
+        case .none:
+            return "Standby"
+        case .resetIntoFirmwareLoader:
+            return "Resetting into Fw Loader Mode"
+        case .requestMcuMgrParameters:
+            return "Requesting McuMgr Parameters"
+        case .bootloaderInfo:
+            return "Requesting Bootloader Info"
+        case .validate:
+            return "Validating"
+        case .upload:
+            return "Uploading"
+        case .eraseAppSettings:
+            return "Erasing App Settings"
+        case .test:
+            return "Testing"
+        case .confirm:
+            return "Confirming"
+        case .reset:
+            return "Resetting"
+        case .success:
+            return "Upload Complete"
+        }
+    }
+    
+    // MARK: isInProgress()
     
     func isInProgress() -> Bool {
         return self != .none


### PR DESCRIPTION
I forget the reason why we hadn't done this before. We've come up with it, and probably the reason is we don't know exactly how other people want to define this. You've all probably done it before and have done so for a long while. But, this step by step rewrite of nRFCDM is also partly a way for us to make the API better, again, by using it ourselves. And having to write this massive switch is like... 'but, why?'