### PR TITLE
Fix for Disappearing Error

### DIFF
--- a/Example/Example/View Controllers/Manager/ImageController+UpgradeDelegate.swift
+++ b/Example/Example/View Controllers/Manager/ImageController+UpgradeDelegate.swift
@@ -20,6 +20,7 @@ extension ImageController: FirmwareUpgradeDelegate {
         uploadCancelButton.isHidden = false
         uploadActionButton.setTitle("Pause", for: .normal)
 
+        dfuError = nil
         initialBytes = 0
         uploadImageSize = nil
         disableActionableButtons()
@@ -49,17 +50,13 @@ extension ImageController: FirmwareUpgradeDelegate {
     }
     
     func upgradeDidFail(inState state: FirmwareUpgradeState, with error: Error) {
+        dfuError = error
+        tableView.reloadSections(IndexSet([Section.sharedUpload.rawValue]), with: .none)
+        
         uploadProgressView.setProgress(0, animated: true)
         uploadCancelButton.isHidden = true
-        uploadSwapButton.isHidden = false
-        uploadBuffersButton.isHidden = false
-        uploadAlignmentButton.isHidden = false
         uploadActionButton.setTitle("Start", for: .normal)
 
-        uploadStateLabel?.textColor = .systemRed
-        uploadStateLabel?.text = error.localizedDescription
-        uploadStateLabel?.numberOfLines = 0
-        uploadSpeedLabel.isHidden = true
         updateActionableButtonsState(for: .none)
     }
     
@@ -139,6 +136,7 @@ extension ImageController: ImageUploadDelegate {
         uploadActionButton.setTitle("Pause", for: .normal)
 
         uploadCancelButton.isHidden = false
+        dfuError = nil
         initialBytes = 0
         uploadImageSize = nil
         

--- a/Example/Example/View Controllers/Manager/ImageController+Upload.swift
+++ b/Example/Example/View Controllers/Manager/ImageController+Upload.swift
@@ -155,8 +155,15 @@ extension ImageController {
             case .fileState:
                 cell.textLabel?.text = "State"
                 
-                cell.detailTextLabel?.text = dfuState?.description ?? "N/A"
-                cell.detailTextLabel?.textColor = dfuState?.associatedColor ?? .secondary
+                if let dfuError {
+                    cell.detailTextLabel?.textColor = .systemRed
+                    cell.detailTextLabel?.text = dfuError.localizedDescription
+                    cell.detailTextLabel?.numberOfLines = 0
+                } else {
+                    cell.detailTextLabel?.text = dfuState?.description ?? "N/A"
+                    cell.detailTextLabel?.textColor = dfuState?.associatedColor ?? .secondary
+                    cell.detailTextLabel?.numberOfLines = 1
+                }
                 uploadStateLabel = cell.detailTextLabel
             case .swapTime:
                 cell.textLabel?.text = "Swap Time"

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -171,6 +171,7 @@ final class ImageController: UITableViewController, ExtendedMcuMgrViewController
     internal var dfuManagerConfiguration = FirmwareUpgradeConfiguration(
         estimatedSwapTime: 10.0, eraseAppSettings: false, pipelineDepth: 3, byteAlignment: .fourByte)
     internal var dfuState: FirmwareUpgradeState?
+    internal var dfuError: (any Error)?
     internal var initialBytes: Int = 0
     internal var uploadImageSize: Int!
     internal var uploadTimestamp: Date!


### PR DESCRIPTION
If we don't hold on to the last received Error, it'll disappear when the cells for the Upload Section are rebuilt. Which can be very confusing for the user.