### PR TITLE
Patch for continuations being resumed more than once

### DIFF
--- a/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
@@ -19,13 +19,16 @@ public extension DefaultManager {
     /// Async variant of ``reset(bootMode:force:callback:)``
     public func reset(bootMode: ResetBootMode = .normal, force: Bool = false) async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
+            var alreadyResumed: Bool = false
             reset(bootMode: bootMode, force: force) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -39,13 +42,16 @@ public extension DefaultManager {
     /// Async variant of ``params(callback:)``
     public func params() async throws -> McuMgrParametersResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrParametersResponse, Error>) in
+            var alreadyResumed: Bool = false
             params { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -59,13 +65,16 @@ public extension DefaultManager {
     /// Async variant of ``applicationInfo(format:callback:)``
     public func applicationInfo(format: Set<ApplicationInfoFormat>) async throws -> AppInfoResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<AppInfoResponse, Error>) in
+            var alreadyResumed: Bool = false
             applicationInfo(format: format) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -90,13 +99,16 @@ public extension DefaultManager {
     /// Async variant of ``bootloaderInfo(query:callback:)``
     public func bootloaderQuery(_ query: BootloaderInfoQuery) async throws -> BootloaderInfoResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BootloaderInfoResponse, Error>) in
+            var alreadyResumed: Bool = false
             bootloaderInfo(query: query) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)

--- a/iOSMcuManagerLibrary/Source/Managers/ImageManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/ImageManager+Async.swift
@@ -16,13 +16,16 @@ public extension ImageManager {
     
     public func list() async throws -> McuMgrImageStateResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrImageStateResponse, Error>) in
+            var alreadyResumed: Bool = false
             list() { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -35,13 +38,16 @@ public extension ImageManager {
     
     public func test(hash: [UInt8]) async throws -> McuMgrImageStateResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrImageStateResponse, Error>) in
+            var alreadyResumed: Bool = false
             test(hash: hash) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -54,13 +60,16 @@ public extension ImageManager {
     
     public func confirm(hash: [UInt8]) async throws -> McuMgrImageStateResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrImageStateResponse, Error>) in
+            var alreadyResumed: Bool = false
             confirm(hash: hash) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -73,13 +82,16 @@ public extension ImageManager {
     
     public func erase(image: Int? = nil, slot: Int? = nil) async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
+            var alreadyResumed: Bool = false
             erase(image: image, slot: slot) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)

--- a/iOSMcuManagerLibrary/Source/Managers/SettingsManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/SettingsManager+Async.swift
@@ -17,13 +17,16 @@ public extension SettingsManager {
     
     public func write(name: String, value: [UInt8]) async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
+            var alreadyResumed: Bool = false
             write(name: name, value: value) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -36,13 +39,16 @@ public extension SettingsManager {
     
     public func save() async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
+            var alreadyResumed: Bool = false
             send(op: .write, commandId: ConfigID.three, payload: nil) { response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
                 }
                 
-                if let response {
+                if let error {
+                    continuation.resume(throwing: error)
+                }else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)

--- a/iOSMcuManagerLibrary/Source/Managers/StatsManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/StatsManager+Async.swift
@@ -18,13 +18,16 @@ public extension StatsManager {
     /// Async variant of ``list(callback:)``
     public func list() async throws -> McuMgrStatsListResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrStatsListResponse, Error>) in
+            var alreadyResumed: Bool = false
             list { response, error in
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
+                }
+                
                 if let error {
                     continuation.resume(throwing: error)
-                    return
-                }
-
-                if let response {
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -38,13 +41,16 @@ public extension StatsManager {
     /// Async variant of ``read(module:callback:)``
     public func read(module: String) async throws -> McuMgrStatsResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrStatsResponse, Error>) in
+            var alreadyResumed: Bool = false
             read(module: module) { response, error in
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
+                }
+                
                 if let error {
                     continuation.resume(throwing: error)
-                    return
-                }
-
-                if let response {
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)

--- a/iOSMcuManagerLibrary/Source/Managers/SuitManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/SuitManager+Async.swift
@@ -16,13 +16,16 @@ public extension SuitManager {
     
     public func listManifest() async throws -> SuitListResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SuitListResponse, Error>) in
+            var alreadyResumed: Bool = false
             listManifest { response, error in
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
+                }
+                
                 if let error {
                     continuation.resume(throwing: error)
-                    return
-                }
-
-                if let response {
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -35,13 +38,16 @@ public extension SuitManager {
     
     public func processRecentlyUploadedEnvelope() async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
+            var alreadyResumed: Bool = false
             processRecentlyUploadedEnvelope() { response, error in
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
+                }
+                
                 if let error {
                     continuation.resume(throwing: error)
-                    return
-                }
-
-                if let response {
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)
@@ -54,13 +60,16 @@ public extension SuitManager {
     
     public func cleanup() async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
+            var alreadyResumed: Bool = false
             cleanup { response, error in
+                guard !alreadyResumed else { return }
+                defer {
+                    alreadyResumed = true
+                }
+                
                 if let error {
                     continuation.resume(throwing: error)
-                    return
-                }
-
-                if let response {
+                } else if let response {
                     continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: McuMgrResponseParseError.invalidPayload)


### PR DESCRIPTION
So, the first question: do we know why this happens? And the answer is yes. The transport "retries" sending packets. And the transport does not know about continuations, it just retries. There are multiple ways to tackle this. The most likely places where this will cause problems is in the DefaultManager for simple commands that usually trigger connection, which is where the retry issue might happen and cause the real issue. I elected, for now, to not make this part of the Transport's problem. Instead the fix is where the "user" is, which is in the async wrappers. We can of course, elect to go about the problem in a different way, one that changes how the lower levels of the transport works, for example. Thing is, this retry saves DFU or restarts it sometimes when the dfu firmware takes time to start accepting data. Or that might be an underlying ROB issue. But, this is to say, we're not writing this to mindlessly get around the problem.