### PR TITLE
Change: Upload / Upgrade Buttons are now in the values themselves

### DIFF
--- a/Example/Example/View Controllers/Manager/FilesController+Upload.swift
+++ b/Example/Example/View Controllers/Manager/FilesController+Upload.swift
@@ -29,6 +29,7 @@ extension FilesController {
             let selectFileButton = UIButton()
             selectFileButton.setTitle("Select File", for: .normal)
             selectFileButton.setTitleColor(.nordic, for: .normal)
+            selectFileButton.setTitleColor(.secondary, for: .disabled)
             selectFileButton.addTarget(self, action: #selector(selectFile), for: .touchUpInside)
             selectFileButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
             selectFileButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Example/Example/View Controllers/Manager/ImageController+Buttons.swift
+++ b/Example/Example/View Controllers/Manager/ImageController+Buttons.swift
@@ -16,31 +16,23 @@ extension ImageController {
     internal func updateActionableButtonsState(for state: FirmwareUpgradeState) {
         switch state {
         case .reset, .upload:
-            uploadCancelButton.isEnabled = true
-            
-            uploadSelectFile?.isEnabled = false
-            uploadCheckForUpdates?.isEnabled = false
-            uploadEraseAppSettingsSwitch?.isEnabled = false
-            
-            resetButton?.isEnabled = false
-            
-            imagesTestButton?.isEnabled = false
-            imagesConfirmButton?.isEnabled = false
-            imagesEraseButton?.isEnabled = false
+            disableActionableButtons()
             return
         default:
             break
         }
         
-        uploadCancelButton.isEnabled = false
+        uploadSelectFile?.isEnabled = !isDFUinProgress()
+        uploadCheckForUpdates?.isEnabled = !isDFUinProgress()
+        uploadEraseAppSettingsSwitch?.isEnabled = !isDFUinProgress()
         
-        uploadSelectFile?.isEnabled = true
-        uploadCheckForUpdates?.isEnabled = true
-        uploadEraseAppSettingsSwitch?.isEnabled = true
+        uploadSwapButton.isEnabled = !isDFUinProgress()
+        uploadBuffersButton.isEnabled = !isDFUinProgress()
+        uploadAlignmentButton.isEnabled = !isDFUinProgress()
         
-        imagesReadButton?.isEnabled = true
-        settingsEraseButton?.isEnabled = true
-        resetButton?.isEnabled = true
+        imagesReadButton?.isEnabled = !isDFUinProgress()
+        settingsEraseButton?.isEnabled = !isDFUinProgress()
+        resetButton?.isEnabled = !isDFUinProgress()
         
         guard let images = readImagesResponse?.images else {
             imagesTestButton?.isEnabled = false
@@ -59,6 +51,10 @@ extension ImageController {
         uploadSelectFile?.isEnabled = false
         uploadCheckForUpdates?.isEnabled = false
         uploadEraseAppSettingsSwitch?.isEnabled = false
+        
+        uploadSwapButton.isEnabled = false
+        uploadBuffersButton.isEnabled = false
+        uploadAlignmentButton.isEnabled = false
         
         imagesReadButton?.isEnabled = false
         imagesTestButton?.isEnabled = false

--- a/Example/Example/View Controllers/Manager/ImageController+Images.swift
+++ b/Example/Example/View Controllers/Manager/ImageController+Images.swift
@@ -45,7 +45,7 @@ extension ImageController {
             let readButton = UIButton()
             readButton.setTitle("Read", for: .normal)
             readButton.setTitleColor(.nordic, for: .normal)
-            readButton.setTitleColor(.nordic.withAlphaComponent(0.5), for: .disabled)
+            readButton.setTitleColor(.secondary, for: .disabled)
             readButton.addTarget(self, action: #selector(imageRead), for: .touchUpInside)
             readButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
             readButton.translatesAutoresizingMaskIntoConstraints = false
@@ -55,7 +55,7 @@ extension ImageController {
             let testButton = UIButton()
             testButton.setTitle("Test", for: .normal)
             testButton.setTitleColor(.nordic, for: .normal)
-            testButton.setTitleColor(.nordic.withAlphaComponent(0.5), for: .disabled)
+            testButton.setTitleColor(.secondary, for: .disabled)
             testButton.addTarget(self, action: #selector(imageTest), for: .touchUpInside)
             testButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
             testButton.translatesAutoresizingMaskIntoConstraints = false
@@ -65,7 +65,7 @@ extension ImageController {
             let confirmButton = UIButton()
             confirmButton.setTitle("Confirm", for: .normal)
             confirmButton.setTitleColor(.nordic, for: .normal)
-            confirmButton.setTitleColor(.nordic.withAlphaComponent(0.5), for: .disabled)
+            confirmButton.setTitleColor(.secondary, for: .disabled)
             confirmButton.addTarget(self, action: #selector(imageConfirm), for: .touchUpInside)
             confirmButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
             confirmButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Example/Example/View Controllers/Manager/ImageController+UpgradeDelegate.swift
+++ b/Example/Example/View Controllers/Manager/ImageController+UpgradeDelegate.swift
@@ -14,16 +14,13 @@ import iOSMcuManagerLibrary
 extension ImageController: FirmwareUpgradeDelegate {
     
     func upgradeDidStart(controller: FirmwareUpgradeController) {
-        uploadSwapButton.isHidden = true
-        uploadBuffersButton.isHidden = true
-        uploadAlignmentButton.isHidden = true
+        disableActionableButtons()
         uploadCancelButton.isHidden = false
         uploadActionButton.setTitle("Pause", for: .normal)
 
         dfuError = nil
         initialBytes = 0
         uploadImageSize = nil
-        disableActionableButtons()
         
         guard let baseController = parent as? BaseViewController else { return }
         baseController.stopObservability()
@@ -34,16 +31,12 @@ extension ImageController: FirmwareUpgradeDelegate {
         tableView.reloadSections(IndexSet([Section.deviceStatus.rawValue]), with: .none)
         tableView.reloadSections(IndexSet([Section.sharedUpload.rawValue]), with: .none)
         
-        uploadCancelButton.isEnabled = isDFUinProgress()
         updateActionableButtonsState(for: newState)
     }
     
     func upgradeDidComplete() {
         uploadProgressView.setProgress(0, animated: false)
         uploadCancelButton.isHidden = true
-        uploadSwapButton.isHidden = false
-        uploadBuffersButton.isHidden = false
-        uploadAlignmentButton.isHidden = false
         uploadActionButton.setTitle("Start", for: .normal)
 
         updateActionableButtonsState(for: .success)
@@ -61,11 +54,11 @@ extension ImageController: FirmwareUpgradeDelegate {
     }
     
     func upgradeDidCancel(state: FirmwareUpgradeState) {
+        dfuState = nil
+        dfuError = nil
+        
         uploadProgressView.setProgress(0, animated: true)
         uploadCancelButton.isHidden = true
-        uploadSwapButton.isHidden = false
-        uploadBuffersButton.isHidden = false
-        uploadAlignmentButton.isHidden = false
         
         uploadStateLabel?.textColor = .secondary
         uploadStateLabel?.text = "CANCELLED"
@@ -130,9 +123,6 @@ extension ImageController: SuitFirmwareUpgradeDelegate {
 extension ImageController: ImageUploadDelegate {
     
     func uploadWillStart() {
-        uploadSwapButton.isHidden = true
-        uploadBuffersButton.isHidden = true
-        uploadAlignmentButton.isHidden = true
         uploadActionButton.setTitle("Pause", for: .normal)
 
         uploadCancelButton.isHidden = false

--- a/Example/Example/View Controllers/Manager/ImageController+Upload.swift
+++ b/Example/Example/View Controllers/Manager/ImageController+Upload.swift
@@ -40,6 +40,7 @@ extension ImageController {
             let selectFileButton = UIButton()
             selectFileButton.setTitle("Select File", for: .normal)
             selectFileButton.setTitleColor(.nordic, for: .normal)
+            selectFileButton.setTitleColor(.secondary, for: .disabled)
             selectFileButton.addTarget(self, action: #selector(selectFirmware), for: .touchUpInside)
             selectFileButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
             selectFileButton.translatesAutoresizingMaskIntoConstraints = false
@@ -65,6 +66,7 @@ extension ImageController {
             let checkOtaButton = UIButton()
             checkOtaButton.setTitle("Check for Updates", for: .normal)
             checkOtaButton.setTitleColor(.nordic, for: .normal)
+            checkOtaButton.setTitleColor(.secondary, for: .disabled)
             checkOtaButton.addTarget(self, action: #selector(checkForUpdates), for: .touchUpInside)
             checkOtaButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
             checkOtaButton.translatesAutoresizingMaskIntoConstraints = false
@@ -146,7 +148,7 @@ extension ImageController {
             }
             
             return cell
-        case .fileState, .swapTime, .numberOfBuffers, .byteAlignment:
+        case .fileState:
             let cell = UITableViewCell(style: .value1, reuseIdentifier: "sharedFileInfo")
             cell.selectionStyle = .none
             cell.textLabel?.font = .preferredFont(forTextStyle: .callout)
@@ -165,24 +167,6 @@ extension ImageController {
                     cell.detailTextLabel?.numberOfLines = 1
                 }
                 uploadStateLabel = cell.detailTextLabel
-            case .swapTime:
-                cell.textLabel?.text = "Swap Time"
-                
-                cell.detailTextLabel?.text = package != nil ? "\(dfuManagerConfiguration.estimatedSwapTime)s" : "N/A"
-                cell.detailTextLabel?.textColor = .secondary
-            case .numberOfBuffers:
-                cell.textLabel?.text = "No. of Buffers"
-                
-                if package != nil {
-                    cell.detailTextLabel?.text = dfuManagerConfiguration.pipelineDepth == 1 ? "Disabled" : "\(dfuManagerConfiguration.pipelineDepth + 1)"
-                } else {
-                    cell.detailTextLabel?.text = "N/A"
-                }
-            case .byteAlignment:
-                cell.textLabel?.text = "Byte Alignment"
-                
-                cell.detailTextLabel?.text = package != nil ? "\(dfuManagerConfiguration.byteAlignment)" : "N/A"
-                cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
             default:
                 cell.textLabel?.text = "N/A"
                 cell.separatorInset = UIEdgeInsets(top: 0, left: tableView.bounds.size.width, bottom: 0, right: 0)
@@ -203,6 +187,86 @@ extension ImageController {
             cell.accessoryView = eraseAppSettingsSwitch
             uploadEraseAppSettingsSwitch = eraseAppSettingsSwitch
             
+            return cell
+        case .swapTime:
+            let identifier = "sharedUploadSwapTime"
+            let cell = tableView.dequeueReusableCell(withIdentifier: identifier) ??
+                UITableViewCell(style: .default, reuseIdentifier: identifier)
+            cell.selectionStyle = .none
+            cell.textLabel?.text = "Swap Time"
+            cell.textLabel?.font = .preferredFont(forTextStyle: .callout)
+            
+            if uploadSwapButton.superview != cell.contentView {
+                uploadSwapButton.removeFromSuperview()
+                cell.contentView.addSubview(uploadSwapButton)
+            }
+            if package != nil {
+                uploadSwapButton.setTitle("\(dfuManagerConfiguration.estimatedSwapTime)s", for: .normal)
+            } else {
+                uploadSwapButton.setTitle("N/A", for: .normal)
+                uploadSwapButton.isEnabled = false
+            }
+            
+            NSLayoutConstraint.activate([
+                uploadSwapButton.topAnchor.constraint(equalTo: cell.contentView.safeAreaLayoutGuide.topAnchor, constant: 8.0),
+                uploadSwapButton.trailingAnchor.constraint(equalTo: cell.contentView.safeAreaLayoutGuide.trailingAnchor, constant: -14.0),
+                
+                cell.contentView.bottomAnchor.constraint(equalTo: uploadSwapButton.bottomAnchor, constant: 8.0)
+            ])
+            return cell
+        case .numberOfBuffers:
+            let identifier = "sharedUploadNumberOfBuffers"
+            let cell = tableView.dequeueReusableCell(withIdentifier: identifier) ??
+                UITableViewCell(style: .default, reuseIdentifier: identifier)
+            cell.selectionStyle = .none
+            cell.textLabel?.text = "No. of Buffers"
+            cell.textLabel?.font = .preferredFont(forTextStyle: .callout)
+            
+            if uploadBuffersButton.superview != cell.contentView {
+                uploadBuffersButton.removeFromSuperview()
+                cell.contentView.addSubview(uploadBuffersButton)
+            }
+            if package != nil {
+                uploadBuffersButton.setTitle(dfuManagerConfiguration.pipelineDepth == 1 ? "Disabled" : "\(dfuManagerConfiguration.pipelineDepth + 1)", for: .normal)
+            } else {
+                uploadBuffersButton.setTitle("N/A", for: .normal)
+                uploadBuffersButton.isEnabled = false
+            }
+            
+            NSLayoutConstraint.activate([
+                uploadBuffersButton.topAnchor.constraint(equalTo: cell.contentView.safeAreaLayoutGuide.topAnchor, constant: 8.0),
+                uploadBuffersButton.trailingAnchor.constraint(equalTo: cell.contentView.safeAreaLayoutGuide.trailingAnchor, constant: -14.0),
+                
+                cell.contentView.bottomAnchor.constraint(equalTo: uploadBuffersButton.bottomAnchor, constant: 8.0)
+            ])
+            return cell
+        case .byteAlignment:
+            let identifier = "sharedUploadByteAlignment"
+            let cell = tableView.dequeueReusableCell(withIdentifier: identifier) ??
+                UITableViewCell(style: .default, reuseIdentifier: identifier)
+            cell.selectionStyle = .none
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
+            
+            cell.textLabel?.text = "Byte Alignment"
+            cell.textLabel?.font = .preferredFont(forTextStyle: .callout)
+            
+            if uploadAlignmentButton.superview != cell.contentView {
+                uploadAlignmentButton.removeFromSuperview()
+                cell.contentView.addSubview(uploadAlignmentButton)
+            }
+            if package != nil {
+                uploadAlignmentButton.setTitle("\(dfuManagerConfiguration.byteAlignment)", for: .normal)
+            } else {
+                uploadAlignmentButton.setTitle("N/A", for: .normal)
+                uploadAlignmentButton.isEnabled = false
+            }
+            
+            NSLayoutConstraint.activate([
+                uploadAlignmentButton.topAnchor.constraint(equalTo: cell.contentView.safeAreaLayoutGuide.topAnchor, constant: 8.0),
+                uploadAlignmentButton.trailingAnchor.constraint(equalTo: cell.contentView.safeAreaLayoutGuide.trailingAnchor, constant: -14.0),
+                
+                cell.contentView.bottomAnchor.constraint(equalTo: uploadAlignmentButton.bottomAnchor, constant: 8.0)
+            ])
             return cell
         case .progressBar:
             let cell = UITableViewCell(style: .default, reuseIdentifier: "progressBar")
@@ -234,24 +298,12 @@ extension ImageController {
             let cell = UITableViewCell(style: .default, reuseIdentifier: "eraseAppSettings")
             cell.selectionStyle = .none
             
-            if uploadSwapButton.superview != nil {
-                uploadSwapButton.removeFromSuperview()
-            }
-            if uploadBuffersButton.superview != nil {
-                uploadBuffersButton.removeFromSuperview()
-            }
-            if uploadAlignmentButton.superview != nil {
-                uploadAlignmentButton.removeFromSuperview()
-            }
             if uploadCancelButton.superview != nil {
                 uploadCancelButton.removeFromSuperview()
             }
             if uploadActionButton.superview != nil {
                 uploadActionButton.removeFromSuperview()
             }
-            cell.contentView.addSubview(uploadSwapButton)
-            cell.contentView.addSubview(uploadBuffersButton)
-            cell.contentView.addSubview(uploadAlignmentButton)
             cell.contentView.addSubview(uploadCancelButton)
             cell.contentView.addSubview(uploadActionButton)
             
@@ -262,16 +314,7 @@ extension ImageController {
                 uploadActionButton.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -14.0),
 
                 uploadCancelButton.centerYAnchor.constraint(equalTo: uploadActionButton.centerYAnchor),
-                uploadCancelButton.trailingAnchor.constraint(equalTo: uploadActionButton.leadingAnchor, constant: -16.0),
-
-                uploadSwapButton.centerYAnchor.constraint(equalTo: uploadActionButton.centerYAnchor),
-                uploadSwapButton.leadingAnchor.constraint(equalTo: cell.contentView.safeLeadingAnchor, constant: 16.0),
-                
-                uploadBuffersButton.centerYAnchor.constraint(equalTo: uploadActionButton.centerYAnchor),
-                uploadBuffersButton.leadingAnchor.constraint(equalTo: uploadSwapButton.trailingAnchor, constant: 14.0),
-                
-                uploadAlignmentButton.centerYAnchor.constraint(equalTo: uploadActionButton.centerYAnchor),
-                uploadAlignmentButton.leadingAnchor.constraint(equalTo: uploadBuffersButton.trailingAnchor, constant: 8.0)
+                uploadCancelButton.trailingAnchor.constraint(equalTo: uploadActionButton.leadingAnchor, constant: -16.0)
             ])
             return cell
         default:

--- a/Example/Example/View Controllers/Manager/ImageController.swift
+++ b/Example/Example/View Controllers/Manager/ImageController.swift
@@ -33,7 +33,7 @@ final class ImageController: UITableViewController, ExtendedMcuMgrViewController
         let button = UIButton()
         button.setTitle("Swap", for: .normal)
         button.setTitleColor(.nordic, for: .normal)
-        button.setTitleColor(.nordic.withAlphaComponent(0.5), for: .disabled)
+        button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(setSwapTime), for: .touchUpInside)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -44,7 +44,7 @@ final class ImageController: UITableViewController, ExtendedMcuMgrViewController
         let button = UIButton()
         button.setTitle("Buffers", for: .normal)
         button.setTitleColor(.nordic, for: .normal)
-        button.setTitleColor(.nordic.withAlphaComponent(0.5), for: .disabled)
+        button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(setPipelineDepth), for: .touchUpInside)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -55,7 +55,7 @@ final class ImageController: UITableViewController, ExtendedMcuMgrViewController
         let button = UIButton()
         button.setTitle("Alignment", for: .normal)
         button.setTitleColor(.nordic, for: .normal)
-        button.setTitleColor(.nordic.withAlphaComponent(0.5), for: .disabled)
+        button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(setByteAlignment), for: .touchUpInside)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -66,7 +66,7 @@ final class ImageController: UITableViewController, ExtendedMcuMgrViewController
         let button = UIButton()
         button.setTitle("Start", for: .normal)
         button.setTitleColor(.nordic, for: .normal)
-        button.setTitleColor(.nordic.withAlphaComponent(0.5), for: .disabled)
+        button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(uploadAction), for: .touchUpInside)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -200,7 +200,10 @@ final class ImageController: UITableViewController, ExtendedMcuMgrViewController
     // MARK: isDFUinProgress()
     
     func isDFUinProgress() -> Bool {
-        dfuManager.isInProgress() || imageManager.isInProgress()
+        guard let dfuManager, let imageManager else {
+            return false
+        }
+        return dfuManager.isInProgress() || imageManager.isInProgress()
     }
     
     // MARK: Handling Basic / Advanced mode


### PR DESCRIPTION
Instead of the previous design, we're making the values of Swap, Buffers and Alignment tappable. Which mirrors the design of the Status section. Should make it more approachable to the user.