### PR TITLE
Exposed McuMgrBleTransport's "autoRetry"

### DIFF
--- a/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
+++ b/iOSMcuManagerLibrary/Source/Bluetooth/McuMgrBleTransport.swift
@@ -246,9 +246,10 @@ extension McuMgrBleTransport: McuMgrTransport {
         log(msg: "Successfully switched to \(mode) mode.", atLevel: .debug)
     }
     
-    public func send<T: McuMgrResponse>(data: Data, timeout: Int, callback: @escaping McuMgrCallback<T>) {
+    public func send<T: McuMgrResponse>(data: Data, timeout: Int, autoRetry: Bool, callback: @escaping McuMgrCallback<T>) {
         operationQueue.addOperation { [weak self] in
-            for i in 0..<McuMgrBleTransportConstant.MAX_RETRIES {
+            let retryCount = autoRetry ? McuMgrBleTransportConstant.MAX_RETRIES : 1
+            for i in 0..<retryCount {
                 switch self?._send(data: data, timeoutInSeconds: timeout) {
                 case .failure(McuMgrTransportError.waitAndRetry):
                     let waitInterval = min(timeout, McuMgrBleTransportConstant.WAIT_AND_RETRY_INTERVAL)

--- a/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/DefaultManager+Async.swift
@@ -19,13 +19,7 @@ public extension DefaultManager {
     /// Async variant of ``reset(bootMode:force:callback:)``
     public func reset(bootMode: ResetBootMode = .normal, force: Bool = false) async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
-            var alreadyResumed: Bool = false
             reset(bootMode: bootMode, force: force) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -42,13 +36,7 @@ public extension DefaultManager {
     /// Async variant of ``params(callback:)``
     public func params() async throws -> McuMgrParametersResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrParametersResponse, Error>) in
-            var alreadyResumed: Bool = false
             params { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -65,13 +53,7 @@ public extension DefaultManager {
     /// Async variant of ``applicationInfo(format:callback:)``
     public func applicationInfo(format: Set<ApplicationInfoFormat>) async throws -> AppInfoResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<AppInfoResponse, Error>) in
-            var alreadyResumed: Bool = false
             applicationInfo(format: format) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -99,13 +81,7 @@ public extension DefaultManager {
     /// Async variant of ``bootloaderInfo(query:callback:)``
     public func bootloaderQuery(_ query: BootloaderInfoQuery) async throws -> BootloaderInfoResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BootloaderInfoResponse, Error>) in
-            var alreadyResumed: Bool = false
             bootloaderInfo(query: query) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {

--- a/iOSMcuManagerLibrary/Source/Managers/FileSystemManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/FileSystemManager.swift
@@ -108,7 +108,7 @@ public class FileSystemManager: McuManager {
             payload.updateValue(CBOR.unsignedInt(UInt64(data.count)), forKey: "len")
         }
         // Build request and send.
-        send(op: .write, commandId: FilesystemID.file, payload: payload, callback: callback)
+        send(op: .write, commandId: FilesystemID.file, payload: payload, autoRetry: true, callback: callback)
     }
     
     // MARK: download(name:delegate:)

--- a/iOSMcuManagerLibrary/Source/Managers/ImageManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/ImageManager+Async.swift
@@ -16,13 +16,7 @@ public extension ImageManager {
     
     public func list() async throws -> McuMgrImageStateResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrImageStateResponse, Error>) in
-            var alreadyResumed: Bool = false
             list() { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -38,13 +32,7 @@ public extension ImageManager {
     
     public func test(hash: [UInt8]) async throws -> McuMgrImageStateResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrImageStateResponse, Error>) in
-            var alreadyResumed: Bool = false
             test(hash: hash) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -60,13 +48,7 @@ public extension ImageManager {
     
     public func confirm(hash: [UInt8]) async throws -> McuMgrImageStateResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrImageStateResponse, Error>) in
-            var alreadyResumed: Bool = false
             confirm(hash: hash) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -82,13 +64,7 @@ public extension ImageManager {
     
     public func erase(image: Int? = nil, slot: Int? = nil) async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
-            var alreadyResumed: Bool = false
             erase(image: image, slot: slot) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {

--- a/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/ImageManager.swift
@@ -173,7 +173,7 @@ public class ImageManager: McuManager {
             uploadTimeoutInSeconds = McuManager.FAST_TIMEOUT
         }
         send(op: .write, commandId: ImageID.upload, payload: payload, timeout: uploadTimeoutInSeconds,
-             callback: callback)
+             autoRetry: true, callback: callback)
     }
     
     // MARK: test(hash:callback:)

--- a/iOSMcuManagerLibrary/Source/Managers/SettingsManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/SettingsManager+Async.swift
@@ -17,13 +17,7 @@ public extension SettingsManager {
     
     public func write(name: String, value: [UInt8]) async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
-            var alreadyResumed: Bool = false
             write(name: name, value: value) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -39,13 +33,7 @@ public extension SettingsManager {
     
     public func save() async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
-            var alreadyResumed: Bool = false
             send(op: .write, commandId: ConfigID.three, payload: nil) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 }else if let response {

--- a/iOSMcuManagerLibrary/Source/Managers/StatsManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/StatsManager+Async.swift
@@ -18,13 +18,7 @@ public extension StatsManager {
     /// Async variant of ``list(callback:)``
     public func list() async throws -> McuMgrStatsListResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrStatsListResponse, Error>) in
-            var alreadyResumed: Bool = false
             list { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -41,13 +35,7 @@ public extension StatsManager {
     /// Async variant of ``read(module:callback:)``
     public func read(module: String) async throws -> McuMgrStatsResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrStatsResponse, Error>) in
-            var alreadyResumed: Bool = false
             read(module: module) { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {

--- a/iOSMcuManagerLibrary/Source/Managers/SuitManager+Async.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/SuitManager+Async.swift
@@ -16,13 +16,7 @@ public extension SuitManager {
     
     public func listManifest() async throws -> SuitListResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SuitListResponse, Error>) in
-            var alreadyResumed: Bool = false
             listManifest { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -38,13 +32,7 @@ public extension SuitManager {
     
     public func processRecentlyUploadedEnvelope() async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
-            var alreadyResumed: Bool = false
             processRecentlyUploadedEnvelope() { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {
@@ -60,13 +48,7 @@ public extension SuitManager {
     
     public func cleanup() async throws -> McuMgrResponse {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<McuMgrResponse, Error>) in
-            var alreadyResumed: Bool = false
             cleanup { response, error in
-                guard !alreadyResumed else { return }
-                defer {
-                    alreadyResumed = true
-                }
-                
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let response {

--- a/iOSMcuManagerLibrary/Source/Managers/SuitManager.swift
+++ b/iOSMcuManagerLibrary/Source/Managers/SuitManager.swift
@@ -303,7 +303,7 @@ public class SuitManager: McuManager {
         let packetLength = maxDataPacketLengthFor(data: data, offset: offset)
         let payload = buildPayload(for: data, at: offset, with: packetLength)
         send(op: .write, commandId: commandID, payload: payload,
-             timeout: uploadTimeoutInSeconds, callback: uploadCallback)
+             timeout: uploadTimeoutInSeconds, autoRetry: true, callback: uploadCallback)
     }
     
     // MARK: uploadCallback

--- a/iOSMcuManagerLibrary/Source/McuManager.swift
+++ b/iOSMcuManagerLibrary/Source/McuManager.swift
@@ -114,14 +114,16 @@ open class McuManager: NSObject {
     
     public func send<T: McuMgrResponse, R: RawRepresentable>(op: McuMgrOperation, commandId: R, payload: [String:CBOR]?,
                                                              timeout: Int = DEFAULT_SEND_TIMEOUT_SECONDS,
+                                                             autoRetry: Bool = false,
                                                              callback: @escaping McuMgrCallback<T>) where R.RawValue == UInt8 {
         return send(op: op, flags: 0, commandId: commandId, payload: payload, timeout: timeout,
-                    callback: callback)
+                    autoRetry: autoRetry, callback: callback)
     }
     
     public func send<T: McuMgrResponse, R: RawRepresentable>(op: McuMgrOperation, flags: UInt8,
                                                              commandId: R, payload: [String:CBOR]?,
                                                              timeout: Int = DEFAULT_SEND_TIMEOUT_SECONDS,
+                                                             autoRetry: Bool,
                                                              callback: @escaping McuMgrCallback<T>) where R.RawValue == UInt8 {
         log(msg: "Sending \(op) command (Version: \(smpVersion), Group: \(group), seq: \(nextSequenceNumber), ID: \(commandId)): \(payload?.debugDescription ?? "nil")",
             atLevel: .verbose)
@@ -160,13 +162,13 @@ open class McuManager: NSObject {
         
         oobBuffer.logDelegate = logDelegate
         oobBuffer.enqueueExpectation(for: packetSequenceNumber)
-        send(data: packetData, timeout: timeout, callback: _callback)
+        send(data: packetData, timeout: timeout, autoRetry: autoRetry, callback: _callback)
         // Use of Overflow operator
         nextSequenceNumber = nextSequenceNumber &+ 1
     }
     
-    public func send<T: McuMgrResponse>(data: Data, timeout: Int, callback: @escaping McuMgrCallback<T>) {
-        transport.send(data: data, timeout: timeout, callback: callback)
+    public func send<T: McuMgrResponse>(data: Data, timeout: Int, autoRetry: Bool, callback: @escaping McuMgrCallback<T>) {
+        transport.send(data: data, timeout: timeout, autoRetry: autoRetry, callback: callback)
     }
     
     //**************************************************************************

--- a/iOSMcuManagerLibrary/Source/McuMgrTransport.swift
+++ b/iOSMcuManagerLibrary/Source/McuMgrTransport.swift
@@ -138,8 +138,9 @@ public protocol McuMgrTransport: AnyObject {
     ///
     /// - parameter data: The data to be sent.
     /// - parameter timeout: The amount of time in seconds to wait before the .send Operation is declared to have failed due to a timeout error if no appropriate response is received.
+    /// - parameter autoRetry: If true, when `callback` is called to report an Error, the transport will attempt a retry on its own, reusing the given `callback`.
     /// - parameter callback: The request callback.
-    func send<T: McuMgrResponse>(data: Data, timeout: Int, callback: @escaping McuMgrCallback<T>)
+    func send<T: McuMgrResponse>(data: Data, timeout: Int, autoRetry: Bool, callback: @escaping McuMgrCallback<T>)
     
     /// Set up a connection to the remote device.
     func connect(_ callback: @escaping ConnectionCallback)


### PR DESCRIPTION
So, there are many ways to fix the 'double or multiple resume continuation' issue. We patched it before but, at the end of the day it hides stuff that we have to mentally keep in mind all the time. With McuMgr library it's not a big deal because we work so much on it but, it's not a good solution. So now, we're reversing it. And, exposing or making it clear that retries are only intended for upload / download operations. That's when they're ultimately useful, really. And, in fact, we could also remove it there, even.