### PR TITLE
Fix: OTAManager now uses NordicLog (when available) for logging

### DIFF
--- a/iOSOtaLibrary/Source/OTA/OTAManager+Logs.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager+Logs.swift
@@ -1,0 +1,33 @@
+//
+//  OTAManager+Logs.swift
+//  iOSMcuManagerLibrary
+//
+//  Created by Dinesh Harjani on 30/07/2026.
+//  Copyright © 2026 Nordic Semiconductor ASA. All rights reserved.
+//
+
+import Foundation
+import iOS_Common_Libraries
+
+// MARK: - Logs
+
+extension OTAManager {
+    
+    func log(_ string: String) {
+        guard #available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *) else {
+            print(string)
+            return
+        }
+        let log = NordicLog(Self.self, subsystem: "com.nordicsemi.ios_ota_library")
+        log.debug(string)
+    }
+    
+    func logError(_ string: String) {
+        guard #available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *) else {
+            print("Error: \(string)")
+            return
+        }
+        let log = NordicLog(Self.self, subsystem: "com.nordicsemi.ios_ota_library")
+        log.error(string)
+    }
+}

--- a/iOSOtaLibrary/Source/OTA/OTAManager.swift
+++ b/iOSOtaLibrary/Source/OTA/OTAManager.swift
@@ -34,7 +34,7 @@ public final class OTAManager {
     // MARK: deinit
     
     deinit {
-        print(#function)
+        log(#function)
         logDelegate = nil
     }
 }


### PR DESCRIPTION
Seeing a random "deinit" text in Xcode logs without knowing who is sending it is not helpful when debugging issues. It sounds very minor, but it is not. It does help. Obviously it's a copy & paste from the ObservabilityManager, but we're not going to write a perfect solution now since we're expecting to raise the minimum SDK sooner rather than later. But not today.