### PR TITLE
Fix for McuMgrCallbackOoOBuffer calling different callbacks for different keys

### DIFF
--- a/iOSMcuManagerLibrary/Source/McuManager.swift
+++ b/iOSMcuManagerLibrary/Source/McuManager.swift
@@ -155,19 +155,7 @@ open class McuManager: NSObject {
             }
             
             do {
-                guard try self.oobBuffer.received((response, error), for: packetSequenceNumber) else { return }
-                try self.oobBuffer.deliver { responseSequenceNumber, response in
-                    let responseResult = response as? (T?, (any Error)?)
-                    if let response = responseResult?.0 {
-                        self.smpVersion = McuMgrVersion(rawValue: response.header.version) ?? .SMPv1
-                        self.log(msg: "Response (\(self.smpVersion), group: \(self.group), seq: \(responseSequenceNumber), command: \(commandId)): \(response)",
-                                 atLevel: .verbose)
-                    } else if let error = responseResult?.1 {
-                        self.log(msg: "Request (\(self.smpVersion), group: \(self.group), seq: \(responseSequenceNumber), command: \(commandId)) failed: \(error.localizedDescription)",
-                                 atLevel: .error)
-                    }
-                    callback(responseResult?.0, responseResult?.1)
-                }
+                try self.oobBuffer.received((response, error), for: packetSequenceNumber)
             } catch let robBufferError {
                 DispatchQueue.main.async {
                     callback(response, robBufferError)
@@ -176,7 +164,18 @@ open class McuManager: NSObject {
         }
         
         oobBuffer.logDelegate = logDelegate
-        oobBuffer.enqueueExpectation(for: packetSequenceNumber)
+        oobBuffer.enqueueKey(packetSequenceNumber) { response in
+            let responseResult = response as? (T?, (any Error)?)
+            if let response = responseResult?.0 {
+                self.smpVersion = McuMgrVersion(rawValue: response.header.version) ?? .SMPv1
+                self.log(msg: "Response (\(self.smpVersion), group: \(self.group), seq: \(packetSequenceNumber), command: \(commandId)): \(response)",
+                         atLevel: .verbose)
+            } else if let error = responseResult?.1 {
+                self.log(msg: "Request (\(self.smpVersion), group: \(self.group), seq: \(packetSequenceNumber), command: \(commandId)) failed: \(error.localizedDescription)",
+                         atLevel: .error)
+            }
+            callback(responseResult?.0, responseResult?.1)
+        }
         send(data: packetData, timeout: timeout, autoRetry: autoRetry, callback: _callback)
     }
     

--- a/iOSMcuManagerLibrary/Source/McuMgrCallbackOoOBuffer.swift
+++ b/iOSMcuManagerLibrary/Source/McuMgrCallbackOoOBuffer.swift
@@ -18,7 +18,7 @@ public struct McuMgrCallbackOoOBuffer<Key: Hashable & Comparable, Value> {
     
     // MARK: BufferError
     
-    enum BufferError: Error {
+    public enum BufferError: Error {
         case empty
         case invalidKey(_ key: Key)
         case noValueForKey(_ key: Key)
@@ -29,10 +29,14 @@ public struct McuMgrCallbackOoOBuffer<Key: Hashable & Comparable, Value> {
     private var internalQueue = DispatchQueue(label: "mcumgr.robbuffer.queue")
     
     private var expectedKeys: [Key] = []
+    
     private var outOfOrderKeys: Set<Key> = []
     private var buffer: [Key: Value] = [:]
+    private var undeliveredKeys: [Key: KeyCallback] = [:]
     
     // MARK: API
+    
+    public typealias KeyCallback = ((Value) -> Void)
     
     public weak var logDelegate: McuMgrLogDelegate?
     
@@ -44,37 +48,50 @@ public struct McuMgrCallbackOoOBuffer<Key: Hashable & Comparable, Value> {
      this function. Subsequent calls to this function should reflect the expected
      order of responses, so for example, if you expect events A, B, C, D, E,
      call in said order.
+     
+     - Parameter key: the key to begin expecting a ``received(_ value: Value, for key: Key)`` call for.
+     - Parameter callback: the specific ``KeyCallback`` attached to the given key.
      */
-    mutating func enqueueExpectation(for key: Key) {
+    mutating public func enqueueKey(_ key: Key, forCallback callback: @escaping KeyCallback) {
         internalQueue.sync {
             expectedKeys.append(key)
+            undeliveredKeys[key] = callback
         }
     }
     
     /**
      Required call when a `Value` is received.
      
-     This function informs the buffer a `Value` has been received. If the
-     buffer recommends proceeding with a call to get a value, which is
-     through the `deliver(to:)` API, it will return true. If not, the buffer
-     is pending reception of values for a different key.
+     It might seem unnecessary to call this if the caller already has the appropriate
+     <Key, Value> pair. But what this call does is trigger delivery of all in-order received
+     ``Value``(s) if none are pending. So if called with a `Value` for a `Key` we're
+     not expecting since it's not the next one (in order), this buffer will wait. Once all
+     pending `Key`(s) are received, then the associated ``KeyCallback`` for each key will
+     be called.
      
-     - returns: `true` if a subsequent call to `deliver(to:)` is suggested.
+     - Parameter value: the latest `Value` that was received.
+     - Parameter key: the specific `Key` attached to the received `Value`.
+     - Throws: If there is a logic error caused by invalid buffer use, a ``BufferError``
+     will be thrown.
      */
-    mutating func received(_ value: Value, for key: Key) throws -> Bool {
+    mutating public func received(_ value: Value, for key: Key) throws {
         try internalQueue.sync {
             guard let i = expectedKeys.firstIndex(where: { $0 == key }) else {
-                if outOfOrderKeys.contains(key) {
-                    buffer[key] = value
-                    log(msg: "Received missing OoO (Out of Order) Key \(key).", atLevel: .debug)
-                    outOfOrderKeys.remove(key)
-                    // Deliver the received key.
-                    return true
-                } else {
+                guard outOfOrderKeys.contains(key) else {
                     throw BufferError.invalidKey(key)
                 }
+                    
+                buffer[key] = value
+                log(msg: "Received missing OoO (Out of Order) Key \(key).", atLevel: .debug)
+                outOfOrderKeys.remove(key)
+                
+                if outOfOrderKeys.isEmpty {
+                    // Deliver all pending keys.
+                    try deliverAllKeysInBuffer()
+                } // else wait for missing keys.
+                return
             }
-            
+
             guard let lowestExpectedKey = expectedKeys.first else {
                 throw BufferError.empty
             }
@@ -82,56 +99,48 @@ public struct McuMgrCallbackOoOBuffer<Key: Hashable & Comparable, Value> {
             buffer[key] = value
 
             let valueReceivedInOrder = i == 0
-            guard !valueReceivedInOrder else {
+            if valueReceivedInOrder {
                 expectedKeys.removeFirst()
-                return true
-            }
-            
-            let lowerKeys = expectedKeys.filter({ $0 < key })
-            lowerKeys.forEach {
-                outOfOrderKeys.insert($0)
-            }
-            
-            log(msg: "Received Value for Key \(key) OoO (Out of Order). Expected \(lowestExpectedKey) instead.",
-                atLevel: .debug)
-            expectedKeys.removeAll(where: { $0 <= key })
-            return false // Wait until we next receive a value.
-        }
-    }
-    
-    /**
-     Call to receive `Value`(s) that have been received thus far.
-     
-     Designed for use in conjunction with `received(_,for:)`. If there are
-     `Value`(s) missing because some have been received out of order, nothing
-     will be returned. See the aforementioned function for more information.
-     
-     - returns: Undelivered `Value`(s) received in order, if none is pending.
-     */
-    mutating func deliver(to callback: @escaping ((Key, Value) -> Void)) throws {
-        try internalQueue.sync {
-            // Wait until there's nothing OoO to return.
-            guard outOfOrderKeys.isEmpty else { return }
-            
-            for key in buffer.keys.sorted(by: <) {
-                guard let value = buffer.removeValue(forKey: key) else {
-                    throw BufferError.noValueForKey(key)
+                try deliverAllKeysInBuffer()
+            } else {
+                let lowerKeys = expectedKeys.filter({ $0 < key })
+                lowerKeys.forEach {
+                    outOfOrderKeys.insert($0)
                 }
                 
-                DispatchQueue.main.async {
-                    callback(key, value)
-                }
+                log(msg: "Received Value for Key \(key) OoO (Out of Order). Expected \(lowestExpectedKey) instead.",
+                    atLevel: .debug)
+                expectedKeys.removeAll(where: { $0 <= key })
+                // Wait until we next receive a value.
             }
         }
     }
 }
 
-private extension McuMgrCallbackOoOBuffer {
+// MARK: - Fileprivate
+
+fileprivate extension McuMgrCallbackOoOBuffer {
+    
+    // MARK: deliverAllKeysInBuffer()
+    
+    mutating func deliverAllKeysInBuffer() throws {
+        for key in buffer.keys.sorted(by: <) {
+            guard let value = buffer.removeValue(forKey: key),
+                  let callback = undeliveredKeys.removeValue(forKey: key) else {
+                throw BufferError.noValueForKey(key)
+            }
+
+            DispatchQueue.main.async {
+                callback(value)
+            }
+        }
+    }
+    
+    // MARK: log(msg:atLevel:)
     
     func log(msg: @autoclosure () -> String, atLevel level: McuMgrLogLevel) {
         if let logDelegate, level >= logDelegate.minLogLevel() {
             logDelegate.log(msg(), ofCategory: .transport, atLevel: level)
         }
     }
-    
 }


### PR DESCRIPTION
So, this issue occurs when there is an 'out of order event', to be specific. If there aren't any, which can happen consistently during many during full DFU(s), then nothing goes wrong. But, when an OoOE happens, then, (for example) callback A for seq. number 14 does not get called, and instead callback B gets called for both seq. number 14 and 15. This is a problem since it leads to double calls on continuations when wrapping callbacks for Swift Concurrency, as well as leaking continuations for the callbacks that are not called. This is, without entering on the basic premise of the logic being wrong :)

So now, the API has been reworked to tie-in a callback with its own key. I mean it's frightening to make these kinds of changes to the very core of the library but, it is a fix for an issue after all.

Current 'How to reproduce:' talk to a QuickStart sample device. Then talk to a device with a Pairing Error, which will trigger multiple parallel calls that will fail. No 'leaked continuation' Swift errors should occur if this fix is working correctly. In general, OoO events on McuMgrBleTransport send() calls under Continuations will trigger Swift failures due to leaked continuations. These things happened before, but they basically caused slowdowns or random errors, instead of breaking the app like it does now. Which is, a good thing, actually.