### PR TITLE
Fix for Files Download / Preview Buttons clipping on Error

### DIFF
--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -141,7 +141,6 @@ final class FilesController: UITableViewController {
         button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(onPreviewButtonTapped), for: .touchUpInside)
         button.setContentHuggingPriority(.required, for: .horizontal)
-        button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
@@ -154,7 +153,6 @@ final class FilesController: UITableViewController {
         button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(onExportButtonTapped), for: .touchUpInside)
         button.setContentHuggingPriority(.required, for: .horizontal)
-        button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button


### PR DESCRIPTION
When there's an Error text, the Error Label pushes the text into the buttons and they allow themselves to be compressed into being truncated. This is now fixed.