### PR TITLE
Fix for clipped Files Download Error

### DIFF
--- a/Example/Example/View Controllers/Manager/FilesController+Download.swift
+++ b/Example/Example/View Controllers/Manager/FilesController+Download.swift
@@ -125,7 +125,8 @@ extension FilesController {
                 downloadResultLabel.leadingAnchor.constraint(equalTo: cell.contentView.safeAreaLayoutGuide.leadingAnchor, constant: 14.0),
                 downloadResultLabel.trailingAnchor.constraint(equalTo: downloadPreviewButton.leadingAnchor, constant: -14.0),
                 
-                cell.contentView.bottomAnchor.constraint(equalTo: downloadPreviewButton.bottomAnchor, constant: 8.0)
+                cell.contentView.bottomAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: downloadPreviewButton.bottomAnchor, multiplier: 1.0),
+                cell.contentView.bottomAnchor.constraint(equalTo: downloadResultLabel.bottomAnchor, constant: 8.0)
             ])
             return cell
         default:

--- a/Example/Example/View Controllers/Manager/FilesController.swift
+++ b/Example/Example/View Controllers/Manager/FilesController.swift
@@ -130,6 +130,7 @@ final class FilesController: UITableViewController {
     internal var downloadResultLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .callout)
+        label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -141,6 +142,7 @@ final class FilesController: UITableViewController {
         button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(onPreviewButtonTapped), for: .touchUpInside)
         button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
@@ -153,6 +155,7 @@ final class FilesController: UITableViewController {
         button.setTitleColor(.secondary, for: .disabled)
         button.addTarget(self, action: #selector(onExportButtonTapped), for: .touchUpInside)
         button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button


### PR DESCRIPTION
We can now read the error completely if it's long enough to require multiple lines.