### PR TITLE
Upgraded ObservabilityManager to support multipart chunk POST Request

### DIFF
--- a/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
+++ b/iOSOtaLibrary/Source/Observability/Data Structures/ObservabilityState.swift
@@ -59,8 +59,13 @@ struct ObservabilityState: Codable {
         return pendingUploads[identifier] ?? []
     }
     
-    func nextChunk(for identifier: UUID) -> ObservabilityChunk? {
-        return pendingChunks(for: identifier).first
+    private static let CHUNK_BATCH_SIZE = 10
+    func nextChunks(for identifier: UUID) -> [ObservabilityChunk]? {
+        let pendingChunks = pendingChunks(for: identifier)
+        guard pendingChunks.hasItems else { return nil }
+        return pendingChunks
+            .prefix(Self.CHUNK_BATCH_SIZE)
+            .toArray()
     }
 }
 

--- a/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
+++ b/iOSOtaLibrary/Source/Observability/ObservabilityManager+Internal.swift
@@ -160,7 +160,6 @@ internal extension ObservabilityManager {
                 }
                 return (auth, chunks)
             }
-            .receive(on: RunLoop.main)
             .sink { [weak self] completion in
                 switch completion {
                 case .finished:
@@ -182,10 +181,10 @@ internal extension ObservabilityManager {
     // MARK: resumeUploadsIfNotBusy
     
     func resumeUploadsIfNotBusy(for identifier: UUID, with auth: ObservabilityAuth) {
-        guard !networkBusy, let nextChunk = state.nextChunk(for: identifier) else { return }
-        log("Sending for Upload Chunk Seq. Number \(nextChunk.sequenceNumber)")
+        guard !networkBusy, let nextChunks = state.nextChunks(for: identifier) else { return }
+        log("Sending for Upload Chunks with Seq. Number \(ListFormatter.localizedString(byJoining: nextChunks.map({ String($0.sequenceNumber) })))")
         networkBusy = true
-        upload(nextChunk, with: auth, from: identifier)
+        upload(nextChunks, with: auth, from: identifier)
     }
     
     // MARK: enqueueRetryPendingUploads
@@ -217,13 +216,17 @@ fileprivate extension ObservabilityManager {
     
     // MARK: upload
     
-    func upload(_ chunk: ObservabilityChunk, with auth: ObservabilityAuth, from identifier: UUID) {
+    func upload(_ chunks: [ObservabilityChunk], with auth: ObservabilityAuth, from identifier: UUID) {
         guard deviceCancellables[identifier] != nil else { return }
-        log("Uploading Chunk Seq. Number \(chunk.sequenceNumber) with Timestamp: \(chunk.timestamp)")
         
-        let uploadingChunk = state.update(chunk, from: identifier, to: .uploading)
-        deviceContinuations[identifier]?.yield((identifier, .updatedChunk(uploadingChunk)))
-        network.perform(HTTPRequest.post(uploadingChunk, with: auth))
+        log("Uploading Chunks with Seq. Number \(ListFormatter.localizedString(byJoining: chunks.map({ String($0.sequenceNumber) })))")
+        let uploadingChunks: [ObservabilityChunk] = chunks.map {
+            let uploadingChunk: ObservabilityChunk! = state.update($0, from: identifier, to: .uploading)
+            deviceContinuations[identifier]?.yield((identifier, .updatedChunk(uploadingChunk)))
+            return uploadingChunk
+        }
+        
+        network.perform(HTTPRequest.post(chunks: uploadingChunks, with: auth))
             .receive(on: RunLoop.main)
             .sink { [weak self] completion in
                 switch completion {
@@ -231,15 +234,19 @@ fileprivate extension ObservabilityManager {
                     self?.log("finished!")
                     self?.networkBusy = false
                 case .failure(let error):
-                    self?.handleError(error, for: uploadingChunk, from: identifier, with: auth)
+                    self?.handleError(error, for: chunks, from: identifier, with: auth)
                 }
             } receiveValue: { [weak self] resultData in
                 guard let self else { return }
-                log("Uploaded Chunk Seq. Number \(uploadingChunk.sequenceNumber) with Timestamp: \(chunk.timestamp)")
-                let successfulChunk = state.update(uploadingChunk, from: identifier, to: .success)
-                deviceContinuations[identifier]?.yield((identifier, .updatedChunk(successfulChunk)))
-                state.clear(successfulChunk, from: identifier)
-                guard let nextUpload = state.nextChunk(for: identifier) else {
+                
+                for uploadedChunk in uploadingChunks {
+                    log("Uploaded Chunk Seq. Number \(uploadedChunk.sequenceNumber) with Timestamp: \(uploadedChunk.timestamp)")
+                    let successfulChunk = state.update(uploadedChunk, from: identifier, to: .success)
+                    deviceContinuations[identifier]?.yield((identifier, .updatedChunk(successfulChunk)))
+                    state.clear(successfulChunk, from: identifier)
+                }
+                
+                guard let nextUpload = state.nextChunks(for: identifier) else {
                     networkBusy = false
                     return
                 }
@@ -250,10 +257,11 @@ fileprivate extension ObservabilityManager {
     
     // MARK: handleError(_:for:from:)
     
-    func handleError(_ error: some Error, for uploadingChunk: ObservabilityChunk, from identifier: UUID, with auth: ObservabilityAuth) {
-        
-        let updatedChunk = state.update(uploadingChunk, from: identifier, to: .uploadError)
-        deviceContinuations[identifier]?.yield((identifier, .updatedChunk(updatedChunk)))
+    func handleError(_ error: some Error, for uploadingChunks: [ObservabilityChunk], from identifier: UUID, with auth: ObservabilityAuth) {
+        for errorChunk in uploadingChunks {
+            state.update(errorChunk, from: identifier, to: .uploadError)
+            deviceContinuations[identifier]?.yield((identifier, .updatedChunk(errorChunk)))
+        }
         networkBusy = false
         if let urlError = error as? URLError,
            let statusCode = urlError.errorUserInfo["httpStatusCode"] as? Int, statusCode == 403 {

--- a/iOSOtaLibrary/Source/Observability/PostChunkRequest.swift
+++ b/iOSOtaLibrary/Source/Observability/PostChunkRequest.swift
@@ -24,6 +24,50 @@ extension HTTPRequest {
         httpRequest.setBody(chunk.data)
         return httpRequest
     }
+    
+    /**
+     - Reference: [Memfault Cloud iOS GitHub Implementation](https://github.com/memfault/memfault-cloud-ios/blob/c40932ac77469e7fe7e18d1d4c126ae47ec92b13/MemfaultCloud/Classes/MemfaultApi.m#L378)
+     */
+    static func post(chunks: [ObservabilityChunk], with chunkAuth: ObservabilityAuth) -> HTTPRequest {
+        if let singleChunk = chunks.first, chunks.count == 1 {
+            return post(singleChunk, with: chunkAuth)
+        }
+        
+        let boundary: String = "--mflt-\(UUID().uuidString)"
+        var httpRequest = HTTPRequest(url: chunkAuth.url)
+        httpRequest.setMethod(HTTPMethod.POST)
+        httpRequest.setHeaders([
+            "Content-Type": "multipart/mixed; boundary=\(boundary)",
+            chunkAuth.authKey: chunkAuth.authValue,
+            "User-Agent": otaLibraryUserAgent()
+        ])
+        
+        var body = Data()
+        for chunk in chunks {
+            if let chunkStart = "--\(boundary)\r\n".data(using: .utf8) {
+                body.append(chunkStart)
+            }
+            
+            if let chunkContentLength = "Content-Length: \(chunk.data.count)".data(using: .utf8) {
+                body.append(chunkContentLength)
+            }
+            
+            if let chunkContentType = "Content-Type: application/octet-stream\r\n\r\n".data(using: .utf8) {
+                body.append(chunkContentType)
+            }
+
+            body.append(chunk.data)
+            if let endOfChunk = "\r\n".data(using: .utf8) {
+                body.append(endOfChunk)
+            }
+        }
+        if let closingData = "--\(boundary)--\r\n".data(using: .utf8) {
+            body.append(closingData)
+        }
+        httpRequest.setBody(body)
+        
+        return httpRequest
+    }
 }
 
 // MARK: - ObservabilityAuth


### PR DESCRIPTION
This is an improvement promoted by our green robot counterparts, who are using a different version / flavor of memfault library. This one is new and written from the ground up, so we were unaware of this side of the API. Over there they use much larger batch sizes, but regardless, this is already a 10x speedup over the previously released version, so it is a win.